### PR TITLE
Removed book_potioncraft from tools

### DIFF
--- a/Arcana/recipe_medsandchemicals.json
+++ b/Arcana/recipe_medsandchemicals.json
@@ -11,7 +11,6 @@
   "book_learn": [[ "book_potioncraft", 0 ]],
   "qualities":[{"id":"CHEM","level":2}],
   "tools": [
-    [ [ "book_potioncraft", -1 ] ],
     [
       [ "hotplate", 10 ],
       [ "char_smoker", 10 ],
@@ -56,7 +55,6 @@
   "book_learn": [[ "book_potioncraft", 1 ]],
   "qualities":[{"id":"CHEM","level":2}],
   "tools": [
-    [ [ "book_potioncraft", -1 ] ],
     [
       [ "hotplate", 10 ],
       [ "char_smoker", 10 ],
@@ -101,7 +99,6 @@
   "book_learn": [[ "book_potioncraft", 2 ]],
   "qualities":[{"id":"CHEM","level":2}],
   "tools": [
-    [ [ "book_potioncraft", -1 ] ],
     [
       [ "hotplate", 10 ],
       [ "char_smoker", 10 ],
@@ -149,7 +146,6 @@
   "book_learn": [[ "book_potioncraft", 3 ]],
   "qualities":[ {"id":"CHEM","level":2}],
   "tools": [
-    [ [ "book_potioncraft", -1 ] ],
     [
       [ "hotplate", 10 ],
       [ "char_smoker", 10 ],


### PR DESCRIPTION
Hi.

The idea is that alchemy is not focused on book magic as much as chemical magic.