### PR TITLE
Rebalancing for wyrmskin armor

### DIFF
--- a/Arcana/materials.json
+++ b/Arcana/materials.json
@@ -35,8 +35,8 @@
             "tattered"
         ],
         "acid_resist" : 99,
-        "elec_resist" : 2,
-        "fire_resist" : 2,
+        "elec_resist" : 0,
+        "fire_resist" : 0,
         "chip_resist" : 10,
         "density" : 6
     }

--- a/Arcana/materials.json
+++ b/Arcana/materials.json
@@ -34,7 +34,7 @@
             "shredded",
             "tattered"
         ],
-        "acid_resist" : 36,
+        "acid_resist" : 99,
         "elec_resist" : 2,
         "fire_resist" : 2,
         "chip_resist" : 10,

--- a/Arcana/recipe_armor.json
+++ b/Arcana/recipe_armor.json
@@ -68,11 +68,14 @@
   "components": [
     [ [ "armor_larmor", 1 ] ],
     [ [ "armguard_larmor", 1 ] ],
+    [ [ "boots_larmor", 1 ] ],
     [ [ "brooch", 1 ] ],
     [
       [ "acid", 1 ],
       [ "water_acid", 2 ],
-      [ "water_acid_weak", 4 ]
+      [ "water_acid_weak", 4 ],
+      [ "chem_sulphuric_acid", 2 ],
+      [ "chem_nitric_acid", 2 ]
     ],
     [ [ "essence_blood", 4 ] ]
   ]

--- a/Arcana/tool_armor.json
+++ b/Arcana/tool_armor.json
@@ -101,8 +101,8 @@
         "description": "A set of leather armor decorated with jade, with serpentine patterns sewn into it.  Using it will conjure a spray of acid.",
         "price": 106000,
         "material": ["wyrmskin", "leather"],
-        "weight": 1954,
-        "volume": 36,
+        "weight": 2830,
+        "volume": 44,
         "bashing": 2,
         "to_hit" : -5,
         "max_charges": 16,
@@ -112,10 +112,10 @@
         "artifact_data" : {
           "effects_activated": ["AEA_ACIDBALL"]
         },
-        "covers" : ["LEGS", "TORSO", "ARMS"],
+        "covers" : ["LEGS", "TORSO", "ARMS", "FEET"],
         "flags" : ["VARSIZE", "STURDY", "NO_SALVAGE"],
         "storage" : 8,
-        "environmental_protection" : 3,
+        "environmental_protection" : 5,
         "warmth" : 25,
         "encumbrance" : 23,
         "coverage" : 90,


### PR DESCRIPTION
Added foot coverage to the wyrmskin armor. Changed volume, weight, and recipe to reflect this inclusion. Additionally increased enviornmental resistance and indcreased natural acid resistance of the relevent material.

Additionally added sulphuric acid and nitric acid as crafting options, due to potential rarity of finding generic acid without electronics skill to dismantle batteries.

Reasoning: The item appears to be intended as acid resistant, but at present lack of foot protection prevents this from applying in most cases, due to acid pools being the most common source of acid damage. Likewise, the actual acid protection provided is minimal.