### PR TITLE
Changes recipes to use chisel qualities

### DIFF
--- a/Arcana/recipe_armor.json
+++ b/Arcana/recipe_armor.json
@@ -89,11 +89,13 @@
   "difficulty": 5,
   "time": 15000,
   "book_learn": [[ "book_bloodmagic", 5 ]],
-  "qualities":[{"id":"HAMMER","level":3}],
+  "qualities":[
+    {"id":"HAMMER","level":3},
+    {"id":"CHISEL","level":3}
+  ],
   "tools": [
     [ [ "book_bloodmagic", -1 ] ],
     [ [ "tongs", -1 ] ],
-    [ [ "chisel", -1 ] ],
     [ [ "anvil", -1 ] ],
     [ [ "swage", -1 ] ],
     [
@@ -116,11 +118,13 @@
   "difficulty": 6,
   "time": 30000,
   "book_learn": [[ "book_sacrifice", 6 ]],
-  "qualities":[{"id":"HAMMER","level":3}],
+  "qualities":[
+    {"id":"HAMMER","level":3},
+    {"id":"CHISEL","level":3}
+  ],
   "tools": [
     [ [ "book_sacrifice", -1 ] ],
     [ [ "tongs", -1 ] ],
-    [ [ "chisel", -1 ] ],
     [ [ "anvil", -1 ] ],
     [ [ "swage", -1 ] ],
     [

--- a/Arcana/recipe_others.json
+++ b/Arcana/recipe_others.json
@@ -73,11 +73,13 @@
   "difficulty": 5,
   "time": 120000,
   "book_learn": [[ "book_sacrifice", 5 ]],
-  "qualities":[{"id":"HAMMER","level":3}],
+  "qualities":[
+    {"id":"HAMMER","level":3},
+    {"id":"CHISEL","level":3}
+  ],
   "tools": [
     [ [ "book_sacrifice", -1 ] ],
     [ [ "tongs", -1 ] ],
-    [ [ "chisel", -1 ] ],
     [ [ "anvil", -1 ] ],
     [ [ "swage", -1 ] ],
     [
@@ -170,12 +172,12 @@
   "book_learn": [[ "book_summoning", 5 ]],
   "qualities":[
     {"id":"HAMMER","level":3},
-    {"id":"CUT","level":1}
+    {"id":"CUT","level":1},
+    {"id":"CHISEL","level":3}
   ],
   "tools": [
     [ [ "book_summoning", -1 ] ],
     [ [ "tongs", -1 ] ],
-    [ [ "chisel", -1 ] ],
     [ [ "anvil", -1 ] ],
     [ [ "swage", -1 ] ],
     [

--- a/Arcana/recipe_weapon.json
+++ b/Arcana/recipe_weapon.json
@@ -9,11 +9,13 @@
   "difficulty": 8,
   "time": 150000,
   "book_learn": [[ "book_sacrifice", 8 ]],
-  "qualities":[{"id":"HAMMER","level":3}],
+  "qualities":[
+    {"id":"HAMMER","level":3},
+    {"id":"CHISEL","level":3}
+  ],
   "tools": [
     [ [ "book_sacrifice", -1 ] ],
     [ [ "tongs", -1 ] ],
-    [ [ "chisel", -1 ] ],
     [ [ "anvil", -1 ] ],
     [ [ "swage", -1 ] ],
     [
@@ -43,11 +45,13 @@
   "difficulty": 3,
   "time": 180000,
   "book_learn": [[ "book_bloodmagic", 3 ]],
-  "qualities":[{"id":"HAMMER","level":3}],
+  "qualities":[
+    {"id":"HAMMER","level":3},
+    {"id":"CHISEL","level":3}
+  ],
   "tools": [
     [ [ "book_bloodmagic", -1 ] ],
     [ [ "tongs", -1 ] ],
-    [ [ "chisel", -1 ] ],
     [ [ "anvil", -1 ] ],
     [ [ "swage", -1 ] ],
     [
@@ -84,11 +88,11 @@
   "difficulty": 6,
   "time": 100000,
   "book_learn": [[ "book_hexenhammer", 6 ]],
+  "qualities":[{"id":"CHISEL","level":3}],
   "tools": [
     [ ["book_hexenhammer", -1] ],
     [ ["hexenhammer", -1] ],
     [ ["tongs", -1] ],
-    [ ["chisel", -1] ],
     [ ["anvil", -1] ],
     [ ["swage", -1] ],
     [
@@ -113,13 +117,13 @@
   "difficulty": 4,
   "time": 100000,
   "book_learn": [[ "book_hexenhammer", 4 ]],
-  "qualities": [
-    {"id":"HAMMER","level":3}
+  "qualities":[
+    {"id":"HAMMER","level":3},
+    {"id":"CHISEL","level":3}
   ],
   "tools": [
     [ ["book_hexenhammer", -1] ],
     [ ["tongs", -1] ],
-    [ ["chisel", -1] ],
     [ ["anvil", -1] ],
     [ ["swage", -1] ],
     [
@@ -149,11 +153,13 @@
   "difficulty": 6,
   "time": 100000,
   "book_learn": [[ "book_bloodmagic", 6 ]],
-  "qualities":[{"id":"HAMMER","level":3}],
+  "qualities":[
+    {"id":"HAMMER","level":3},
+    {"id":"CHISEL","level":3}
+  ],
   "tools": [
     [ [ "book_bloodmagic", -1 ] ],
     [ [ "tongs", -1 ] ],
-    [ [ "chisel", -1 ] ],
     [ [ "anvil", -1 ] ],
     [ [ "swage", -1 ] ],
     [
@@ -198,11 +204,13 @@
   "difficulty": 7,
   "time": 200000,
   "book_learn": [[ "book_hexenhammer", 7 ]],
-  "qualities":[{"id":"HAMMER","level":3}],
+  "qualities":[
+    {"id":"HAMMER","level":3},
+    {"id":"CHISEL","level":3}
+  ],
   "tools": [
     [ [ "book_hexenhammer", -1 ] ],
     [ [ "tongs", -1 ] ],
-    [ [ "chisel", -1 ] ],
     [ [ "anvil", -1 ] ],
     [ [ "swage", -1 ] ],
     [


### PR DESCRIPTION
Updates recipes involving the chisel to make use of chisel as a quality instead of a tool. Reasoning is that chiselling tools now make use of qualities and can presumably be used to exclude recipes if makeshift versions are ever implemented.

This change was originally added to the obsolete version of the mod in the Cataclysm DDA repository by another user, see pull request: https://github.com/CleverRaven/Cataclysm-DDA/pull/20081