### PR TITLE
Adds EASY_DECONSTRUCT flag to upright sword

### DIFF
--- a/Arcana/furniture.json
+++ b/Arcana/furniture.json
@@ -15,6 +15,6 @@
       "items": [ { "item": "sun_sword", "count": 1 } ]
     },
     "deconstruct": { "items": [ { "item": "sun_sword", "count": 1 } ] },
-    "flags": [ "TRANSPARENT" ]
+    "flags": [ "TRANSPARENT", "EASY_DECONSTRUCT" ]
   }
 ]


### PR DESCRIPTION
This pull request adds the flag that enables deconstruction without tools to the upright weapon.

The relevant pull request is https://github.com/CleverRaven/Cataclysm-DDA/pull/21402

My apologies for having been delayed in porting over this change, but some things came up recently, and I had not been as active as of late.