### PR TITLE
Ruined shrines, 3 new items

### DIFF
--- a/Arcana/armor.json
+++ b/Arcana/armor.json
@@ -21,5 +21,19 @@
     "material_thickness": 1,
     "artifact_data": { "effects_worn": [ "AEP_CARRY_MORE", "AEP_FORCE_TELEPORT", "AEP_ATTENTION" ] },
     "flags": [ "WAIST", "OVERSIZE" ]
+  },
+  {
+    "id": "meteoric_talisman",
+    "type": "ARMOR",
+    "name": "meteoric talisman",
+    "description": "An ornate necklace with a small charm resembling a round shield, made from a hard iridescent metal.  Wearing it will ward against electricity, but it slows the body.",
+    "weight": 60,
+    "volume": 1,
+    "price": 12000,
+    "material": [ "hardsteel" ],
+    "symbol": "[",
+    "color": "light_gray",
+    "artifact_data": { "effects_worn": [ "AEP_RESIST_ELECTRICITY", "AEP_SPEED_DOWN" ] },
+    "flags": [ "FANCY" ]
   }
 ]

--- a/Arcana/effects.json
+++ b/Arcana/effects.json
@@ -102,6 +102,30 @@
         }
     },{
         "type": "effect_type",
+        "id": "cold_ward",
+        "name": ["Ward Against Cold"],
+        "desc": ["Protection against the effects of cold."],
+        "remove_message": "For a moment you feel a terrible chill in the air, as the moonstone fang's power fades.",
+        "removes_effects": [ "cold", "frostbite", "frostbite_recovery" ],
+        "blocks_effects": [ "cold", "frostbite", "frostbite_recovery" ],
+        "max_duration": 1000,
+        "base_mods": {
+            "str_mod": [-1]
+        }
+    },{
+        "type": "effect_type",
+        "id": "heat_ward",
+        "name": ["Ward Against Heat"],
+        "desc": ["Protection against most effects of heat."],
+        "remove_message": "You feel a strange tingling sensation, as the jade wreath's power fades.",
+        "removes_effects": [ "onfire", "smoke", "hot", "blisters" ],
+        "blocks_effects": [ "onfire", "smoke", "hot", "blisters" ],
+        "max_duration": 1000,
+        "base_mods": {
+            "dex_mod": [-1]
+        }
+    },{
+        "type": "effect_type",
         "id": "cleric_warding",
         "name": ["Ward Against Evil"],
         "desc": ["Protects against various anomalous effects."],

--- a/Arcana/mapgen_shrines.json
+++ b/Arcana/mapgen_shrines.json
@@ -1,0 +1,210 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "shrine_anomaly" ],
+    "weight": 300,
+    "object": {
+      "fill_ter": "t_floor",
+      "rows": [
+        "                        ",
+        "                        ",
+        "  O                  O  ",
+        "        mmmmmmmm        ",
+        "       mmppppppmm       ",
+        "      mmppppppppmm      ",
+        "     mmppp,,_,pppmm     ",
+        "    mmppp,,,,,,pppmm    ",
+        "   mmpppO......Opppmm   ",
+        "   mppp,........,pppm   ",
+        "   mpp,,........,,ppm   ",
+        "   mpp_,........,,ppm   ",
+        "   mpp,,........,_ppm   ",
+        "   mpp,,........,,ppm   ",
+        "   mppp,........,pppm   ",
+        "   mmpppO......Opppmm   ",
+        "    mmppp,,,,,,pppmm    ",
+        "     mmppp,_,,pppmm     ",
+        "      mmppppppppmm      ",
+        "       mmppppppmm       ",
+        "        mmmmmmmm        ",
+        "  O                  O  ",
+        "                        ",
+        "                        "
+      ],
+      "terrain": {
+        " ": [ "t_dirt", "t_dirt", "t_dirt", "t_grass", "t_shrub" ],
+        ",": "t_dirt",
+        ".": "t_pavement",
+        "O": "t_column",
+        "p": "t_pit_shallow",
+        "m": "t_rock_floor",
+        "_": "t_dirt"
+      },
+      "set": [
+        { "point": "trap", "id": "tr_brazier", "x": 12, "y": 6 },
+        { "point": "trap", "id": "tr_brazier", "x": 17, "y": 12 },
+
+        { "point": "trap", "id": "tr_brazier", "x": 11, "y": 17 },
+
+        { "point": "trap", "id": "tr_brazier", "x": 6, "y": 11 },
+        { "point": "trap", "id": "tr_glow", "x": [ 9, 14 ], "y": [ 9, 14 ], "repeat": [ 2, 3 ] },
+        { "point": "trap", "id": "tr_hum", "x": [ 9, 14 ], "y": [ 9, 14 ], "repeat": [ 2, 3 ] },
+        { "point": "trap", "id": "tr_drain", "x": [ 9, 14 ], "y": [ 9, 14 ], "repeat": [ 2, 3 ] }
+      ],
+      "place_loot": [
+        { "group": "cult_sacrifice", "x": 12, "y": 6 },
+        { "group": "cult_sacrifice", "x": 17, "y": 12 },
+        { "group": "cult_sacrifice", "x": 11, "y": 17 },
+        { "group": "cult_sacrifice", "x": 6, "y": 11 },
+        { "item": "meteoric_talisman", "x": [ 11, 12 ], "y": [ 11, 12 ] }
+      ],
+      "place_monsters": [
+        { "monster": "GROUP_IMPACT_FLYING", "x": [ 6, 17 ], "y": [ 6, 17 ], "density": 0.1 }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "shrine_anomaly" ],
+    "weight": 300,
+    "object": {
+      "fill_ter": "t_floor",
+      "rows": [
+        "                        ",
+        "  #TTTTTT##,,##TTTTTT#  ",
+        " ##T,,,,,,,,,,,,,,,,T## ",
+        " TT,,TTTTT#++#TTTTT,,TT ",
+        " T,,##............##,,T ",
+        " T,##..O........O..##,T ",
+        " T,TB..............BT,T ",
+        " T,TB..O........O..BT,T ",
+        " T,TB..............BT,T ",
+        " #,TB..O........O..BT,# ",
+        " #,#B..............B#,# ",
+        " ,,########++########,, ",
+        " ,,#................#,, ",
+        " #,#.b....C..C....b.#,# ",
+        " #,#.b..C......C..b.#,# ",
+        " T,#.b............b.#,T ",
+        " T,#.b............b.#,T ",
+        " T,#....C......C....#,T ",
+        " T,##.....C..C.....##,T ",
+        " T,,##.....RR.....##,,T ",
+        " TT,,##############,,TT ",
+        " ##T,,,,,,,,,,,,,,,,T## ",
+        "  #TTTTTT##,,##TTTTTT#  ",
+        "                        "
+      ],
+      "terrain": {
+        " ": [ "t_grass", "t_grass", "t_grass", "t_shrub", "t_shrub", "t_dirt" ],
+        "T": [ "t_rock_smooth", "t_rock_smooth", "t_dirt", "t_lava" ],
+        "#": "t_rock_smooth",
+        ",": "t_pavement",
+        "O": "t_column",
+        ".": "t_rock_floor",
+        "B": "t_rock_floor",
+        "C": "t_rock_floor",
+        "R": "t_rock_floor",
+        "+": "t_door_locked"
+      },
+      "furniture": {
+        "B": "f_bookcase",
+        "b": "f_bench",
+        "R": "f_rack",
+        "C": "f_coffin_o"
+      },
+      "place_loot": [
+        { "group": "summoner_casualties", "x": 10, "y": 13, "chance": 80 },
+        { "group": "summoner_casualties", "x": 13, "y": 13, "chance": 80 },
+        { "group": "summoner_casualties", "x": 8, "y": 14, "chance": 80 },
+        { "group": "summoner_casualties", "x": 15, "y": 14, "chance": 80 },
+        { "group": "summoner_casualties", "x": 8, "y": 17, "chance": 80 },
+        { "group": "summoner_casualties", "x": 15, "y": 17, "chance": 80 },
+        { "group": "summoner_casualties", "x": 10, "y": 18, "chance": 80 },
+        { "group": "summoner_casualties", "x": 13, "y": 18, "chance": 80 },
+        { "group": "unaligned_arcanist_books", "x": 4, "y": [ 6, 10 ], "chance": 40, "repeat": [ 2, 6 ] },
+        { "group": "unaligned_arcanist_books", "x": 19, "y": [ 6, 10 ], "chance": 40, "repeat": [ 2, 6 ] },
+        { "item": "essence_blood", "x": [ 11, 12 ], "y": 19, "chance": 50, "repeat": [ 5, 10 ] },
+        { "item": "jade_wreath", "x": [ 11, 12 ], "y": 19 }
+      ],
+      "place_monster": [
+        { "monster": "mon_dementia", "x": [ 8, 15 ], "y": [ 5, 10 ], "repeat": [ 3, 6 ] },
+        { "monster": "mon_blood_sacrifice", "x": 10, "y": 10 },
+        { "monster": "mon_blood_sacrifice", "x": 13, "y": 10 },
+        { "monster": "mon_shoggoth", "x": 11, "y": 15, "chance": 50 }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "shrine_anomaly" ],
+    "weight": 300,
+    "object": {
+      "fill_ter": "t_floor",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "   wwwwwwss  sswwwwww   ",
+        "   w                w   ",
+        "   w ######++###### w   ",
+        "   w #bbb..__..rrr# w   ",
+        "   w #.....__.....# w   ",
+        "   w #..O.O__O.O..# w   ",
+        "   s #.....__.....# s   ",
+        "   s #..O.____.O..# s   ",
+        "     +_____tt_____+     ",
+        "     +_____tt_____+     ",
+        "   s #..O.____.O..# s   ",
+        "   s #.....__.....# s   ",
+        "   w #..O.O__O.O..# w   ",
+        "   w #.....__.....# w   ",
+        "   w #rrr..__..bbb# w   ",
+        "   w ######++###### w   ",
+        "   w                w   ",
+        "   wwwwwwss  sswwwwww   ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "terrain": {
+        " ": [ "t_dirt", "t_dirt", "t_grass", "t_shrub", "t_water_sh", "t_swater_sh" ],
+        "#": "t_wall",
+        "s": "t_water_sh",
+        "w": "t_water_dp",
+        ".": "t_rock_floor",
+        "+": "t_door_locked",
+        "O": "t_column",
+        "b": "t_rock_floor",
+        "r": "t_rock_floor",
+        "t": "t_carpet_green",
+        "_": "t_carpet_green"
+      },
+      "furniture": {
+        "b": "f_bookcase",
+        "r": "f_rack",
+        "t": "f_table"
+      },
+      "set": [
+        { "point": "trap", "id": "tr_snake", "x": [ 6, 17 ], "y": [ 6, 17 ], "repeat": [ 5, 10 ] }
+      ],
+      "place_loot": [
+        { "group": "unaligned_arcanist_books", "x": [ 6, 8 ], "y": 6, "chance": 40, "repeat": [ 2, 4 ] },
+        { "group": "magic_items", "x": [ 15, 17 ], "y": 6, "chance": 40, "repeat": [ 2, 4 ] },
+        { "group": "magic_consumables", "x": [ 6, 8 ], "y": 17, "chance": 40, "repeat": [ 2, 4 ] },
+        { "group": "unaligned_arcanist_books", "x": [ 15, 17 ], "y": 17, "chance": 40, "repeat": [ 2, 4 ] },
+        { "item": "moonstone_fang", "x": [ 11, 12 ], "y": [ 11, 12 ] }
+      ],
+      "place_monster": [
+        { "monster": "mon_rattlesnake", "x": [ 0, 23 ], "y": [ 0, 4 ], "repeat": [ 2, 4 ] },
+        { "monster": "mon_rattlesnake_giant", "x": [ 0, 23 ], "y": [ 19, 23 ], "repeat": [ 2, 4 ] },
+        { "monster": "mon_sewer_snake", "x": [ 0, 4 ], "y": [ 0, 23 ], "repeat": [ 3, 6 ] },
+        { "monster": "mon_sewer_snake", "x": [ 19, 23 ], "y": [ 0, 23 ], "repeat": [ 3, 6 ] },
+        { "monster": "mon_twisted_body", "x": 11, "y": 15, "chance": 50 }
+      ]
+    }
+  }
+]

--- a/Arcana/overmap_specials.json
+++ b/Arcana/overmap_specials.json
@@ -70,5 +70,18 @@
         "occurrences" : [1, 1],
         "rotate" : false,
         "flags" : [ "CLASSIC" ]
+    },{
+        "type" : "overmap_special",
+        "id" : "Ruined Shrine",
+        "overmaps" :
+        [
+            { "point":[0,0,0], "overmap": "shrine_anomaly"}
+        ],
+        "locations" : [ "wilderness", "swamp" ],
+        "city_distance" : [0, -1],
+        "city_sizes" : [1, 12],
+        "occurrences" : [0, 3],
+        "rotate" : false,
+        "flags" : [ "CLASSIC" ]
     }
 ]

--- a/Arcana/overmap_terrain.json
+++ b/Arcana/overmap_terrain.json
@@ -232,5 +232,15 @@
     "color": "blue",
     "see_cost": 5,
     "flags": [ "NO_ROTATE" ]
+  },
+  {
+    "id": "shrine_anomaly",
+    "type": "overmap_terrain",
+    "name": "ruined shrine",
+    "sym": 83,
+    "color": "light_gray",
+    "see_cost": 5,
+    "extras": "field",
+    "flags": [ "NO_ROTATE" ]
   }
 ]

--- a/Arcana/ranged.json
+++ b/Arcana/ranged.json
@@ -27,8 +27,7 @@
     "reload": 400,
     "ammo_effects": [ "LIGHTNING", "BOUNCE" ],
     "artifact_data": {
-      "effects_carried": [ "AEP_BAD_WEATHER" ],
-      "effects_wielded": [ "AEP_RESIST_ELECTRICITY" ]
+      "effects_carried": [ "AEP_BAD_WEATHER" ]
     },
     "flags": [ "NEVER_JAMS", "PRIMITIVE_RANGED_WEAPON" ]
   },

--- a/Arcana/recipe_deconstruction.json
+++ b/Arcana/recipe_deconstruction.json
@@ -77,6 +77,42 @@
     ]
   },
   {
+    "result": "meteoric_talisman",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 5,
+    "time": 50000,
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [
+      [ [ "scrap", 1 ] ],
+      [ [ "essence_dull", 50 ] ]
+    ]
+  },
+  {
+    "result": "jade_wreath",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 5,
+    "time": 50000,
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [
+      [ [ "material_sand", 12 ] ],
+      [ [ "essence_dull", 50 ] ]
+    ]
+  },
+  {
+    "result": "moonstone_fang",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 0,
+    "time": 50000,
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [
+      [ [ "material_sand", 6 ] ],
+      [ [ "essence_dull", 50 ] ]
+    ]
+  },
+  {
     "result": "essence",
     "type": "uncraft",
     "skill_used": "magic",

--- a/Arcana/tool_armor.json
+++ b/Arcana/tool_armor.json
@@ -138,7 +138,6 @@
     "coverage": 20,
     "encumbrance": 0,
     "material_thickness": 1,
-    "artifact_data": { "effects_worn": [ "AEP_EXTINGUISH", "AEP_SICK" ] },
     "use_action": {
       "type": "consume_drug",
       "activation_message": "The diamond shimmers with malevolent red light as you feel a strange hunger, a craving for rotting meat and stagnant water...",
@@ -238,6 +237,35 @@
     "environmental_protection": 1,
     "use_action": "TAZER",
     "flags": [ "VARSIZE", "STURDY", "NO_SALVAGE" ]
+  },
+  {
+    "id": "jade_wreath",
+    "type": "TOOL_ARMOR",
+    "category": "clothing",
+    "name": "jade wreath",
+    "description": "A crown of dark green stone with strange geometric patterns carved into it.  Wearing it will drain heat from fires, but it will also starve your body.  Invoking it will harden the body against heat, though immersion in flame will still harm you.",
+    "weight": 600,
+    "volume": 12,
+    "price": 90000,
+    "to_hit": -1,
+    "material": [ "stone" ],
+    "symbol": "[",
+    "color": "green",
+    "ammo": "essence_blood_type",
+    "//": "Slightly more efficient in essence-equivalent than fang, as heat resistance is less comprehensive.",
+    "max_charges": 20,
+    "charges_per_use": 20,
+    "covers": [ "HEAD" ],
+    "coverage": 20,
+    "encumbrance": 10,
+    "material_thickness": 1,
+    "artifact_data": { "effects_worn": [ "AEP_EXTINGUISH", "AEP_HUNGER" ] },
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "The carvings in the stone glow red for a brief moment, and a chill passes through your spine.",
+      "effects": [ { "id": "flame_ward", "duration": 1000 } ]
+    },
+    "flags": [ "BELTED", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "cleric_ring",

--- a/Arcana/tools.json
+++ b/Arcana/tools.json
@@ -1165,6 +1165,34 @@
     ]
   },
   {
+    "id": "moonstone_fang",
+    "type": "TOOL",
+    "category": "weapons",
+    "name": "moonstone fang",
+    "description": "A short, curved spike made of a white opalescent gemstone, richly engraved with swirling serpentine imagery.  Wielding it will call forth serpentine shadows to aid you and grant a life-draining touch, but it will sicken body and mind.  Invoking it will harden the body against cold.",
+    "weight": 160,
+    "volume": 6,
+    "price": 25000,
+    "to_hit": 2,
+    "bashing": 3,
+    "cutting": 22,
+    "material": "stone",
+    "symbol": "/",
+    "color": "dark_gray",
+    "ammo": "essence_type",
+    "max_charges": 10,
+    "charges_per_use": 10,
+    "techniques": [ "RAPID", "DEF_DISARM" ],
+    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 6 ] ],
+    "artifact_data": { "effects_wielded": [ "AEP_SNAKES", "AEP_SAP_LIFE", "AEP_SICK", "AEP_SCHIZO" ] },
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "The carvings in the stone glow blue for a brief moment, and an uncomfortable warmth spreads through your body.",
+      "effects": [ { "id": "cold_ward", "duration": 1000 } ]
+    },
+    "flags": [ "STAB", "SHEATH_KNIFE" ]
+  },
+  {
     "id": "stormbringer",
     "type": "TOOL",
     "category": "weapons",

--- a/Arcana/tools.json
+++ b/Arcana/tools.json
@@ -1183,7 +1183,7 @@
     "max_charges": 10,
     "charges_per_use": 10,
     "techniques": [ "RAPID", "DEF_DISARM" ],
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 6 ] ],
+    "qualities": [ [ "BUTCHER", 6 ] ],
     "artifact_data": { "effects_wielded": [ "AEP_SNAKES", "AEP_SAP_LIFE", "AEP_SICK", "AEP_SCHIZO" ] },
     "use_action": {
       "type": "consume_drug",


### PR DESCRIPTION
Self-PR for the hell of it, makes feedback easier. o3o

* Adds three optional locations full of anomalies, monsters, and other Fun stuff, as sources of some new items.
* Meteoric talisman, your basic passive item that lets you no-sell electricity when worn.
* Moonstone fang. Decent stabbing weapon, can procure sneks and drain life when wielded, with some side effects. Activation lets you straight-up no-sell freezing to death for a while (immunity to being chilly, frostbite, and frostbite recovery).
* Jade wreath. Doesn't do much besides eat fires when worn, but activating it gives immunity to being warm, smoke inhalation, blistering, and catching on fire. Actually standing in fire will still fuck you up though.
* Some assorted effects were removed from existing items now that other items're meant to use them.