### PR TITLE
Upgrade mask of insight

### DIFF
--- a/Arcana/tool_armor.json
+++ b/Arcana/tool_armor.json
@@ -81,7 +81,7 @@
     "warmth": 10,
     "material_thickness": 2,
     "environmental_protection": 6,
-    "artifact_data": { "effects_worn": [ "AEP_CLAIRVOYANCE" ] },
+    "artifact_data": { "effects_worn": [ "AEP_CLAIRVOYANCE_PLUS" ] },
     "qualities": [ [ "GLARE", 2 ] ],
     "use_action": {
       "target": "somen_clairvoyance",


### PR DESCRIPTION
With https://github.com/CleverRaven/Cataclysm-DDA/pull/21758 now mainlined, the mask of insight can now use this flag to make a it a proper tool as discussed. This PR just changes the tag.