### PR TITLE
Brazier conversion, trap to furniture

### DIFF
--- a/Arcana/mapgen_basements.json
+++ b/Arcana/mapgen_basements.json
@@ -73,10 +73,6 @@
         "                        ",
         "                        "
       ],
-      "set": [
-        { "point": "trap", "id": "tr_brazier", "x": 4, "y": 13 },
-        { "point": "trap", "id": "tr_brazier", "x": 7, "y": 13 }
-      ],
       "terrain": {
         "#": "t_rock_floor",
         "+": "t_door_c",
@@ -93,7 +89,8 @@
         "#": "f_counter",
         "]": "f_bookcase",
         "h": "f_chair",
-        "{": "f_rack"
+        "{": "f_rack",
+        "b": "f_brazier"
       },
       "place_loot": [
         { "group": "cult_sacrifice", "x": 4, "y": 13, "chance": 100 },
@@ -147,10 +144,6 @@
         "                        ",
         "                        "
       ],
-      "set": [
-        { "point": "trap", "id": "tr_brazier", "x": 7, "y": 2 },
-        { "point": "trap", "id": "tr_brazier", "x": 15, "y": 2 }
-      ],
       "terrain": {
         "#": "t_rock_floor",
         "+": "t_door_c",
@@ -171,7 +164,8 @@
         "D": "f_dresser",
         "]": "f_bookcase",
         "p": "f_bench",
-        "{": "f_rack"
+        "{": "f_rack",
+        "b": "f_brazier"
       },
       "place_loot": [
         { "item": "holy_symbol", "x": 11, "y": 2, "chance": 90 },
@@ -222,10 +216,6 @@
         "                        ",
         "                        "
       ],
-      "set": [
-        { "point": "trap", "id": "tr_brazier", "x": 11, "y": 18 },
-        { "point": "trap", "id": "tr_portal", "x": 11, "y": 20 }
-      ],
       "terrain": {
         "#": "t_rock_floor",
         "+": "t_door_c",
@@ -245,7 +235,8 @@
         "#": "f_counter",
         "]": "f_bookcase",
         "p": "f_bench",
-        "{": "f_rack"
+        "{": "f_rack",
+        "b": "f_brazier"
       },
       "place_loot": [
         { "item": "offering_chalice_used", "x": 11, "y": 19, "chance": 100 },

--- a/Arcana/mapgen_chaliceimpact.json
+++ b/Arcana/mapgen_chaliceimpact.json
@@ -111,12 +111,6 @@
         "..........^..^..........",
         "........................"
       ],
-      "set": [
-        { "point": "trap", "id": "tr_brazier", "x": 8, "y": 8 },
-        { "point": "trap", "id": "tr_brazier", "x": 15, "y": 8 },
-        { "point": "trap", "id": "tr_brazier", "x": 8, "y": 15 },
-        { "point": "trap", "id": "tr_brazier", "x": 15, "y": 15 }
-      ],
       "terrain": {
         " ": "t_rock_floor",
         ".": "t_dirt",
@@ -124,6 +118,9 @@
         "B": "t_rock_floor",
         "P": "t_little_column",
         "^": "t_pit_shallow"
+      },
+      "furniture": {
+        "B": "f_brazier"
       },
       "place_loot": [
         { "group": "cult_sacrifice", "x": 8, "y": 8, "chance": 100 },
@@ -389,12 +386,6 @@
         "////////########////////",
         "////////////////////////"
       ],
-      "set": [
-        { "point": "trap", "id": "tr_brazier", "x": 9, "y": 2 },
-        { "point": "trap", "id": "tr_brazier", "x": 9, "y": 7 },
-        { "point": "trap", "id": "tr_brazier", "x": 14, "y": 2 },
-        { "point": "trap", "id": "tr_brazier", "x": 14, "y": 7 }
-      ],
       "mapping": {
         "b": {
           "furniture": "f_bed",
@@ -430,7 +421,8 @@
         "D": "f_desk",
         "b": "f_bed",
         "c": "f_bookcase",
-        "d": "f_dresser"
+        "d": "f_dresser",
+        "B": "f_brazier"
       },
       "place_loot": [
         { "group": "chalice_cult_casualty_special", "x": 11, "y": 4 },

--- a/Arcana/mapgen_cleansingflame.json
+++ b/Arcana/mapgen_cleansingflame.json
@@ -134,10 +134,6 @@
         "   |-111-|     |-111-|  ",
         "                        "
       ],
-      "set": [
-        { "point": "trap", "id": "tr_brazier", "x": 9, "y": 9 },
-        { "point": "trap", "id": "tr_brazier", "x": 15, "y": 9 }
-      ],
       "mapping": {
         "B": {
           "furniture": "f_bed",
@@ -187,7 +183,8 @@
         "o": "f_oven",
         "s": "f_sink",
         "t": "f_bathtub",
-        "v": "f_woodstove"
+        "v": "f_woodstove",
+        "u": "f_brazier"
       },
       "toilets": {
         "T": {}

--- a/Arcana/mapgen_sanguine.json
+++ b/Arcana/mapgen_sanguine.json
@@ -329,12 +329,6 @@
         "          #.``.#+#b..#..",
         "          #.==.#.....+.<"
       ],
-      "set": [
-        { "point": "trap", "id": "tr_brazier", "x": 22, "y": 18 },
-        { "point": "trap", "id": "tr_brazier", "x": 18, "y": 22 },
-        { "point": "trap", "id": "tr_brazier", "x": 20, "y": 2 },
-        { "point": "trap", "id": "tr_brazier", "x": 20, "y": 5 }
-      ],
       "mapping": {
         "B": {
           "furniture": "f_bed",
@@ -370,7 +364,8 @@
         "C": "f_bookcase",
         "D": "f_desk",
         "c": "f_chair",
-        "d": "f_dresser"
+        "d": "f_dresser",
+        "b": "f_brazier"
       },
       "place_loot": [
         { "item": "note_sanguine", "x": [ 22, 23 ], "y": [ 22, 23 ], "chance": 100 },
@@ -424,15 +419,7 @@
         "<.+.....#.==.#          "
       ],
       "set": [
-        { "point": "trap", "id": "tr_portal", "x": 0, "y": 3 },
-        { "point": "trap", "id": "tr_brazier", "x": 13, "y": 4 },
-        { "point": "trap", "id": "tr_brazier", "x": 7, "y": 10 },
-        { "point": "trap", "id": "tr_brazier", "x": 19, "y": 10 },
-        { "point": "trap", "id": "tr_brazier", "x": 13, "y": 16 },
-        { "point": "trap", "id": "tr_brazier", "x": 1, "y": 18 },
-        { "point": "trap", "id": "tr_brazier", "x": 5, "y": 22 },
-        { "point": "trap", "id": "tr_brazier", "x": 3, "y": 2 },
-        { "point": "trap", "id": "tr_brazier", "x": 3, "y": 5 }
+        { "point": "trap", "id": "tr_portal", "x": 0, "y": 3 }
       ],
       "mapping": {
         "t": {
@@ -459,7 +446,8 @@
         "~": "t_water_dp"
       },
       "furniture": {
-        "t": "f_table"
+        "t": "f_table",
+        "b": "f_brazier"
       },
       "place_loot": [
         { "group": "cult_sacrifice", "x": 13, "y": 4, "chance": 25 },
@@ -509,14 +497,6 @@
         "                        ",
         "                        "
       ],
-      "set": [
-        { "point": "trap", "id": "tr_brazier", "x": 10, "y": 7 },
-        { "point": "trap", "id": "tr_brazier", "x": 4, "y": 13 },
-        { "point": "trap", "id": "tr_brazier", "x": 16, "y": 13 },
-        { "point": "trap", "id": "tr_brazier", "x": 10, "y": 19 },
-        { "point": "trap", "id": "tr_brazier", "x": 18, "y": 1 },
-        { "point": "trap", "id": "tr_brazier", "x": 22, "y": 5 }
-      ],
       "mapping": {
         "t": {
           "furniture": "f_table",
@@ -540,7 +520,8 @@
         "~": "t_water_dp"
       },
       "furniture": {
-        "t": "f_table"
+        "t": "f_table",
+        "b": "f_brazier"
       },
       "place_loot": [
         { "group": "cult_sacrifice", "x": 10, "y": 7, "chance": 25 },
@@ -588,10 +569,6 @@
         "                        ",
         "                        "
       ],
-      "set": [
-        { "point": "trap", "id": "tr_brazier", "x": 5, "y": 1 },
-        { "point": "trap", "id": "tr_brazier", "x": 1, "y": 5 }
-      ],
       "mapping": {
         "B": {
           "furniture": "f_bed",
@@ -625,7 +602,8 @@
         "C": "f_bookcase",
         "D": "f_desk",
         "c": "f_chair",
-        "d": "f_dresser"
+        "d": "f_dresser",
+        "b": "f_brazier"
       },
       "place_loot": [
         { "group": "cult_sacrifice", "x": 5, "y": 1, "chance": 25 },


### PR DESCRIPTION
* Converts the braziers from traps to furniture. Updated build of CDDA or Coolthulhu's Patch will be needed.

Thanks to Dean over in the Dwarf Fortress discord for pointing this out, because *AAAAH* the bloody thing @Night-Pryanik PR'd was merged literally a week ago and I never noticed it.