### PR TITLE
Fireball fix

### DIFF
--- a/Arcana/magic_signs.json
+++ b/Arcana/magic_signs.json
@@ -651,7 +651,7 @@
     "max_charges": 1,
     "charges_per_use": 1,
     "turns_per_charge": 1,
-    "artifact_data": { "effects_activated": [ "AEA_ACIDBALL" ] },
+    "artifact_data": { "effects_activated": [ "AEA_FIREBALL" ] },
     "use_action": "ARTIFACT"
   },
   {


### PR DESCRIPTION
Fireball Magic sign was set to shoot acid instead of fire