### PR TITLE
Assorted stuff

### DIFF
--- a/Arcana/NC_FILES.json
+++ b/Arcana/NC_FILES.json
@@ -47,12 +47,11 @@
       { "item": "pants" },
       { "item": "dress_shirt" },
       { "item": "robe" },
-      { "item": "hat_knit" },
       { "item": "knit_scarf" },
       { "item": "gloves_leather" },
       { "item": "socks" },
       { "item": "boots_hiking" },
-      { "item": "duffelbag" },
+      { "item": "backpack" },
       { "item": "glasses_eye" },
       { "item": "charm_bone" }
     ]
@@ -74,7 +73,7 @@
       { "item": "arcanemap", "prob": 50 },
       { "item": "book_sacrifice" },
       { "item": "offering_chalice" },
-      { "group": "magic_consumables", "count": [ 4, 8 ] }
+      { "group": "magic_consumables", "count": [ 2, 4 ] }
     ]
   },
   {

--- a/Arcana/crafting_requirements.json
+++ b/Arcana/crafting_requirements.json
@@ -72,7 +72,7 @@
     "type": "requirement",
     "//": "Tools and components for writing scrolls, old-school style.  No ink is used, hence no consuming charcoal markers.",
     "tools": [
-      [ [ "torch_lit", -1 ], [ "candle_lit", -1 ], [ "oil_lamp_on", -1 ], [ "fire", -1 ] ],
+      [ [ "torch_lit", -1 ], [ "candle_lit", -1 ], [ "oil_lamp_on", -1 ], [ "candle_warding_active", -1 ], [ "fire", -1 ] ],
       [ [ "survival_marker", -1 ], [ "feather", -1 ] ]
     ],
     "components": [ [ [ "scroll_blank", 1 ] ] ]
@@ -89,7 +89,7 @@
     "type": "requirement",
     "//": "Tools and components for writing down essential elements of an arcane book for tool use.  No ink is used, hence no consuming charcoal markers.",
     "tools": [
-      [ [ "torch_lit", -1 ], [ "candle_lit", -1 ], [ "oil_lamp_on", -1 ], [ "fire", -1 ] ],
+      [ [ "torch_lit", -1 ], [ "candle_lit", -1 ], [ "oil_lamp_on", -1 ], [ "candle_warding_active", -1 ], [ "fire", -1 ] ],
       [ [ "survival_marker", -1 ], [ "feather", -1 ] ]
     ],
     "components": [ [ [ "paper", 20 ] ], [ [ "arcana_essence_any", 1, "LIST" ] ] ]

--- a/Arcana/furniture.json
+++ b/Arcana/furniture.json
@@ -23,7 +23,7 @@
     "bgcolor": [ "blue" ],
     "move_cost_mod": -2,
     "required_str": -1,
-    "flags": [ "NOITEM", "TRANSPARENT" ],
+    "flags": [ "NOITEM", "TRANSPARENT", "USABLE_FIRE" ],
     "deployed_item": "candle_barrier_aftermath",
     "examine_action": "deployed_furniture"
   },
@@ -37,7 +37,7 @@
     "bgcolor": [ "magenta" ],
     "move_cost_mod": -2,
     "required_str": -1,
-    "flags": [ "NOITEM", "TRANSPARENT" ],
+    "flags": [ "NOITEM", "TRANSPARENT", "USABLE_FIRE" ],
     "deployed_item": "candle",
     "examine_action": "deployed_furniture",
     "bash": {

--- a/Arcana/recipe_deconstruction.json
+++ b/Arcana/recipe_deconstruction.json
@@ -92,7 +92,7 @@
     "result": "moonstone_fang",
     "type": "uncraft",
     "skill_used": "magic",
-    "difficulty": 0,
+    "difficulty": 5,
     "time": 50000,
     "tools": [ [ [ "hexenhammer", -1 ] ] ],
     "components": [ [ [ "material_sand", 6 ] ], [ [ "essence_dull", 50 ] ] ]
@@ -105,6 +105,15 @@
     "time": 40000,
     "tools": [ [ [ "hexenhammer", -1 ] ] ],
     "components": [ [ [ "copper", 100 ] ], [ [ "essence_dull", 45 ] ] ]
+  },
+  {
+    "result": "candle_warding",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 3,
+    "time": 30000,
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "essence_dull", 10 ] ] ]
   },
   {
     "result": "offering_chalice",

--- a/Arcana/recipe_weapon.json
+++ b/Arcana/recipe_weapon.json
@@ -151,7 +151,7 @@
     "tools": [
       [ [ "book_sacrifice", -1 ] ],
       [ [ "book_bloodmagic", -1 ] ],
-      [ [ "torch_lit", -1 ], [ "candle_lit", -1 ], [ "oil_lamp_on", -1 ], [ "fire", -1 ] ],
+      [ [ "torch_lit", -1 ], [ "candle_lit", -1 ], [ "oil_lamp_on", -1 ], [ "candle_warding_active", -1 ], [ "fire", -1 ] ],
       [
         [ "holy_symbol", -1 ],
         [ "holy_symbol_wood", -1 ],

--- a/Arcana/tools.json
+++ b/Arcana/tools.json
@@ -192,7 +192,7 @@
     "revert_to": "sun_sword",
     "techniques": [ "WBLOCK_2", "VORPAL" ],
     "use_action": [
-      { "type": "firestarter", "moves": 15 },
+      { "type": "firestarter", "moves": 30 },
       { "menu_text": "Turn off", "type": "transform", "msg": "The sword's radiance fades.", "target": "sun_sword" }
     ],
     "relative": { "cutting": 5 },
@@ -1328,17 +1328,18 @@
   },
   {
     "id": "flame_talisman",
-    "type": "COMESTIBLE",
-    "comestible_type": "MED",
-    "category": "tools",
+    "type": "TOOL",
     "name": "flame talisman",
-    "description": "A crude paper talisman marked with strange patterns, and annointed with a meager sacrifice.  It can be used to rapidly spark a fire, if you're desperate.",
+    "description": "A crude paper talisman marked with strange patterns, and annointed with a meager sacrifice.  It can be used to rapidly spark a fire, if you're desparate.",
     "weight": 150,
-    "volume": 1,
+    "volume": "100 ml",
     "material": "paper",
     "symbol": ",",
     "color": "cyan",
-    "use_action": { "type": "firestarter", "moves": 10 },
+    "initial_charges": 15,
+    "max_charges": 15,
+    "charges_per_use": 1,
+    "use_action": { "type": "firestarter", "moves": 5 },
     "flags": [ "NO_SALVAGE" ]
   },
   {
@@ -1349,7 +1350,7 @@
     "name": "water talisman",
     "description": "A crude paper talisman marked with strange patterns, and annointed with a hunter's sacrifice.  It can be used to mend minor wounds, along with providing limited resistance to certain alchemical effects.",
     "weight": 150,
-    "volume": 1,
+    "volume": "100 ml",
     "material": "paper",
     "symbol": ",",
     "color": "cyan",
@@ -1376,7 +1377,7 @@
     "name": "earth talisman",
     "description": "A crude paper talisman marked with strange patterns, and annointed with a peculiar sacrifice.  Using it will conjure and transmutate a structure of strange earth and stone, to serve as a meager shelter in times of desparation.",
     "weight": 150,
-    "volume": 1,
+    "volume": "100 ml",
     "material": "paper",
     "symbol": ",",
     "color": "cyan",
@@ -1397,15 +1398,47 @@
     "type": "TOOL",
     "name": "candle of warding",
     "name_plural": "candle of warding",
-    "description": "A candle with translucent wax, free of any impurities with a soothing aura about it.  Though its ghostly blue flame emits neither light nor heat, it can be used to place a magical barrier.  The barrier this item creates is not indestructable, but it is tough.",
+    "description": "A candle with translucent wax, free of any impurities with a soothing aura about it.  It can be used to place a magical barrier, or used to project a faint light.  The barrier this item creates is not indestructable, but it is tough.",
     "weight": 100,
     "volume": 1,
     "price": 1000,
     "material": "essencemat",
     "symbol": ",",
     "color": "white",
-    "use_action": { "type": "deploy_furn", "furn_type": "f_candle_barrier_playermade" },
+    "use_action": [
+      {
+        "target": "candle_warding_active",
+        "msg": "The candle gives off a faint blue flame.",
+        "menu_text": "Light candle of warding",
+        "type": "transform"
+      },
+      { "type": "deploy_furn", "furn_type": "f_candle_barrier_playermade" }
+    ],
     "flags": [ "NO_SALVAGE" ]
+  },
+  {
+    "id": "candle_warding_active",
+    "type": "TOOL",
+    "name": "candle of warding (on)",
+    "name_plural": "candle of warding (on)",
+    "description": "A candle with translucent wax, free of any impurities with a soothing aura about it.  Its wick is lit with a ghostly blue flame, projecting light without heat.  It can also be used to place a magical barrier, one that's tough but not indestructable.",
+    "looks_like": "candle_warding",
+    "weight": 100,
+    "volume": 1,
+    "price": 1000,
+    "material": "essencemat",
+    "symbol": ",",
+    "color": "white",
+    "use_action": [
+      {
+        "target": "candle_warding_active",
+        "msg": "The candle's wick is extinguished.",
+        "menu_text": "Extinguish candle of warding",
+        "type": "transform"
+      },
+      { "type": "deploy_furn", "furn_type": "f_candle_barrier_playermade" }
+    ],
+    "flags": [ "NO_SALVAGE", "LIGHT_8" ]
   },
   {
     "id": "orb_veil",


### PR DESCRIPTION
Self-PRing mostly because I didn't think I'd get enough time today to finish this batch of ideas up, and thought I might have to do a commit-for-remote to bounce it from laptop to desktop.

* Made it so that you can toggle candle of warding on and off, granting a small amount of light when active. Also made it so that an active candle of warding counts as a valid tool when crafting with recipes that require ritual lighting.
* Gave deployed candle barriers USABLE_FIRE, per a suggestion I received.
* Some proposed rebalances of talisman items. Lowered volume and no longer needs cutting quality to make, and moreover flame talismans have multiple uses.
* Some tweaks to speed of firestarting items so that flame talisman's ignition speed is more noticeable relative to the other arcane items.
* Fixed arcana level needed to uncraft moonstone fang.
* Added option to dismantle candle of warding.
* Minor tweaks to the hermit's outfit.

I was gonna give the hermit a couple of the cosmetic traits, but need to grab latest build and confirm that hair traits have stopped looking stupid. Either that or mod_tileset on a sprite that adequately covers up the current default hair and beard on male characters. First we needed Skinhead Steve to leave for 0.D, now we need him back. :eyes: