### PR TITLE
Rebalancing Dragonblood

### DIFF
--- a/Arcana/mutations.json
+++ b/Arcana/mutations.json
@@ -1123,7 +1123,7 @@
     "purifiable": false,
     "category": [ "DRAGONBLOOD", "DRAGONBLOODLESSER" ],
     "prereqs": [ "ARCANA_INNERFIRE" ],
-    "armor": [ { "parts": "ALL", "heat": 10 } ]
+    "armor": [ { "parts": "ALL", "heat": 6 } ]
   },
   {
     "type": "mutation",
@@ -1207,6 +1207,7 @@
     "prereqs": [ "ARCANA_SCALYPATCHES", "ARCANA_DRAGONSCALES" ],
     "changes_to": [ "ARCANA_DRAGONWINGS" ],
     "encumbrance_always": [ [ "TORSO", 10 ] ],
+    "encumbrance_covered": [ [ "TORSO", 5 ] ],
     "category": [ "DRAGONBLOOD", "DRAGONBLOODLESSER" ],
     "types": [ "WINGS" ],
     "restricts_gear": [ "TORSO" ],
@@ -1225,6 +1226,7 @@
     "prereqs": [ "ARCANA_SCALYWINGS" ],
     "threshreq": [ "THRESH_DRAGONBLOOD" ],
     "category": [ "DRAGONBLOOD" ],
+    "encumbrance_always": [ [ "TORSO", 5 ] ],
     "encumbrance_covered": [ [ "TORSO", 5 ] ],
     "types": [ "WINGS" ],
     "max_stamina_modifier": 1.1,
@@ -1239,12 +1241,13 @@
     "points": 2,
     "visibility": 3,
     "ugliness": 2,
-    "description": "You have sharply curved claws on the ends of your fingers, allowing you to make an extra attack when conditions favor it.  However, they do get in the way a bit if you are wearing gloves.",
+    "description": "You have sharply curved claws on the ends of your fingers, allowing you to make an extra attack when conditions favor it.  However, they do get in the way a bit, especially if you are wearing gloves.",
     "valid": false,
     "purifiable": false,
     "types": [ "CLAWS" ],
     "category": [ "DRAGONBLOOD", "DRAGONBLOODLESSER" ],
-    "encumbrance_covered": [ [ "HAND_L", 10 ], [ "HAND_R", 10 ] ],
+    "encumbrance_always": [ [ "HAND_L", 5 ], [ "HAND_R", 5 ] ],
+    "encumbrance_covered": [ [ "HAND_L", 5 ], [ "HAND_R", 5 ] ],
     "attacks": [
       {
         "attack_text_u": "You slash %s with your claws",
@@ -1309,7 +1312,7 @@
     "visibility": 5,
     "ugliness": 2,
     "mixed_effect": true,
-    "description": "Your legs have been altered into a digitigrade structure ending in wickedly sharp talons, preventing you from wearing footwear and making it hard to walk, especially on rough terrain.  On the plus side, you can kick with them rather effectively.",
+    "description": "Your legs have been altered into a digitigrade structure ending in wickedly sharp talons, preventing you from wearing footwear and making it hard to walk, especially on rough terrain.  It's even worse if you try to wear anything over them.  On the plus side, you can kick with them rather effectively.",
     "valid": false,
     "purifiable": false,
     "category": [ "DRAGONBLOOD" ],
@@ -1318,9 +1321,11 @@
     "changes_to": [ "ARCANA_DRAGONLEGS" ],
     "types": [ "LEGS" ],
     "encumbrance_always": [ [ "LEG_L", 10 ], [ "LEG_R", 10 ], [ "FOOT_L", 10 ], [ "FOOT_R", 10 ] ],
+    "encumbrance_covered": [ [ "LEG_L", 10 ], [ "LEG_R", 10 ], [ "FOOT_L", 10 ], [ "FOOT_R", 10 ] ],
     "restricts_gear": [ "FOOT_L", "FOOT_R" ],
     "destroys_gear": true,
-    "movecost_obstacle_modifier": 1.2,
+    "movecost_obstacle_modifier": 1.3,
+    "movecost_flatground_modifier": 0.9,
     "noise_modifier": 2.0,
     "attacks": [
       {
@@ -1339,19 +1344,19 @@
     "visibility": 5,
     "ugliness": 2,
     "mixed_effect": true,
-    "description": "Your legs have been altered into a digitigrade structure ending in wickedly sharp talons.  While you still can't wear footwear, your new legs have adapted to a bipedal structure, making them much less awkward.  Rough terrain is still a slight hindrance, but you can move a bit faster on level ground.",
+    "description": "Your legs have been altered into a digitigrade structure ending in wickedly sharp talons.  While you still can't wear footwear, your new legs have adapted to a bipedal structure, making them much less awkward.  Rough terrain is still a hindrance and they're better left uncovered, but you can move a bit faster on level ground.",
     "valid": false,
     "purifiable": false,
     "category": [ "DRAGONBLOOD" ],
     "prereqs": [ "ARCANA_SCALYLEGS" ],
     "threshreq": [ "THRESH_DRAGONBLOOD" ],
     "types": [ "LEGS" ],
-    "encumbrance_covered": [ [ "LEG_L", 5 ], [ "LEG_R", 5 ] ],
-    "passive_mods": { "dex_mod": 1 },
+    "encumbrance_always": [ [ "LEG_L", 5 ], [ "LEG_R", 5 ], [ "FOOT_L", 5 ], [ "FOOT_R", 5 ] ],
+    "encumbrance_covered": [ [ "LEG_L", 5 ], [ "LEG_R", 5 ], [ "FOOT_L", 5 ], [ "FOOT_R", 5 ] ],
     "restricts_gear": [ "FOOT_L", "FOOT_R" ],
     "destroys_gear": true,
-    "movecost_obstacle_modifier": 1.1,
-    "movecost_flatground_modifier": 0.9,
+    "movecost_obstacle_modifier": 1.2,
+    "movecost_flatground_modifier": 0.8,
     "noise_modifier": 1.5,
     "attacks": [
       {
@@ -1378,7 +1383,6 @@
     "types": [ "TAIL" ],
     "restricts_gear": [ "LEG_L", "LEG_R" ],
     "allow_soft_gear": true,
-    "passive_mods": { "dex_mod": 2 },
     "attacks": {
       "attack_text_u": "You whip %s with your tail",
       "attack_text_npc": "%1$s whips %2$s with their tail",
@@ -1402,7 +1406,6 @@
     "types": [ "TAIL" ],
     "restricts_gear": [ "LEG_L", "LEG_R" ],
     "allow_soft_gear": true,
-    "passive_mods": { "dex_mod": 2 },
     "attacks": {
       "attack_text_u": "You lash %s with your tail",
       "attack_text_npc": "%1$s lashes %2$s with their tail",
@@ -1427,7 +1430,7 @@
     "types": [ "HORNS" ],
     "restricts_gear": [ "HEAD" ],
     "allow_soft_gear": true,
-    "armor": [ { "parts": "HEAD", "bash": 10, "cut": 15 } ],
+    "armor": [ { "parts": "HEAD", "bash": 5, "cut": 10 } ],
     "attacks": {
       "attack_text_u": "You headbutt %s",
       "attack_text_npc": "%1$s headbutts %2$s",
@@ -1451,8 +1454,9 @@
     "category": [ "DRAGONBLOOD" ],
     "threshreq": [ "THRESH_DRAGONBLOOD" ],
     "wet_protection": [ { "part": "TORSO", "ignored": 15 } ],
-    "encumbrance_always": [ [ "TORSO", 10 ] ],
-    "armor": [ { "parts": "TORSO", "bash": 10, "cut": 25 } ]
+    "encumbrance_always": [ [ "TORSO", 5 ] ],
+    "encumbrance_covered": [ [ "TORSO", 5 ] ],
+    "armor": [ { "parts": "TORSO", "bash": 5, "cut": 15 } ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
Obligatory self-PR for feedback.

* Reduced heat protection of Elemental Affinity. It still likely will make wading through fire rather less damaging, but less likely to be 100% immunity.
* Added both static and covered encumbrance to Scaly Wings as well as Draconic wings. Net increase is effectively +5 encumbrance for either if wearing anything on the torso.
* Split the encumbrance for Curved Claws between static and covered, instead of only taking effect when wearing gloves. They would still mess with delicate actions, after all.
* Basically doubled the encumbrance for both Scaly Hind Limbs and Draconic Hind Limbs, via adding both static encumbrance and covered encumbrance to both. Also increased the movecost buffs AND debuffs for both leg mutations.
* Removed dexterity buffs from leg and tail mutations, as they're better off covered by dodge and speed modifiers.
* Reduced the armor values of Swept-Back Horns and Draconic Plating. Swept-Back Horns in particular would only be giving partial protection anyway.
* Split up the encumbrance of Draconic Plating into static and covered encumbrance. Since this was previously static-only, this is the only one that's technically a buff instead of a nerf.

The main upshot of this is that running around half-naked no longer mitigates the encumbrance penalties for late-game Dragonblood ENTIRELY, and the armor is less full-on bulletproof, making that playstyle neither cheap nor 100% effective. It also takes away the stat focus on dex, making its stat buffs limited to strength, which still plays to its strengths (especially with natural attacks being strength-derived) without getting free bonuses to a stat that makes it trivial to capitalize on those buffs, which in turn means your pre-existing dex and skills remain important. The increased, harder-to-mitigate encumberance also plays with this, blunting the speed/movement advantages (and potentially justifying increasing them if requested) while making the debuffs stand out more.