### PR TITLE
Enchantment extra stuff, part one

### DIFF
--- a/Arcana/ranged.json
+++ b/Arcana/ranged.json
@@ -28,6 +28,15 @@
     "reload": 400,
     "ammo_effects": [ "LIGHTNING", "BOUNCE", "EMP" ],
     "artifact_data": { "effects_wielded": [ "AEP_BAD_WEATHER" ] },
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WIELD",
+          "condition": "ALWAYS",
+          "hit_you_effect": [ { "id": "arcana_react_symbol_judgment_wonder" } ]
+        }
+      ]
+    },
     "flags": [ "BELT_CLIP", "NEVER_JAMS", "PRIMITIVE_RANGED_WEAPON", "MAGIC_FOCUS" ],
     "use_action": "MEDITATE"
   },
@@ -152,6 +161,15 @@
     "loudness": 75,
     "clip_size": 4,
     "reload": 200,
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WIELD",
+          "condition": "ALWAYS",
+          "hit_you_effect": [ { "id": "arcana_react_bane_staff_venom" } ]
+        }
+      ]
+    },
     "ammo_effects": [ "ACIDBOMB", "TOXICGAS" ],
     "techniques": [ "WBLOCK_1", "RAPID" ],
     "flags": [ "UNBREAKABLE_MELEE", "NEVER_JAMS", "PRIMITIVE_RANGED_WEAPON", "NONCONDUCTIVE", "NO_SALVAGE", "MAGIC_FOCUS" ]

--- a/Arcana/spells.json
+++ b/Arcana/spells.json
@@ -1448,7 +1448,7 @@
   {
     "type": "SPELL",
     "id": "arcana_item_scroll_nature_mutate_dragonblood",
-    "name": "Divine Scroll: Nature Mutation (Lesser Dragonblood)",
+    "name": "Divine Scroll: Nature Mutation 1",
     "effect": "mutate",
     "effect_str": "DRAGONBLOODLESSER",
     "description": "Comparable to Artifact Mutate, except mimics effect of blood effigy.",
@@ -1461,7 +1461,7 @@
   {
     "type": "SPELL",
     "id": "arcana_item_scroll_nature_mutate_plant",
-    "name": "Divine Scroll: Nature Mutation (Plant)",
+    "name": "Divine Scroll: Nature Mutation 2",
     "effect": "mutate",
     "effect_str": "PLANT",
     "description": "Comparable to Artifact Mutate, except focused on Plant category.",
@@ -2037,7 +2037,7 @@
     "id": "arcana_magic_lightning_ward",
     "type": "SPELL",
     "name": "Sign: Lightning Ward",
-    "description": "Magic Sign\nUsing this spell will anoint you with an amber halo, granting you immunity to lightning.",
+    "description": "Magic Sign\nUsing this spell will anoint you with an amber halo, granting you resistance to lightning.",
     "message": "\"One foot after the other, always grounded...\"  You cast %s!",
     "valid_targets": [ "self" ],
     "flags": [ "NO_HANDS", "NO_LEGS", "VERBAL" ],
@@ -2654,5 +2654,71 @@
     "duration_increment": 3000,
     "energy_source": "HP",
     "spell_class": "SPELL_HUNT_DRAGONBLOOD"
+  },
+  {
+    "id": "arcana_react_bane_staff_venom",
+    "type": "SPELL",
+    "name": "React: Venom",
+    "description": "Inflicts a bit of biological damage and poison.",
+    "message": "",
+    "flags": [ "SILENT", "RANDOM_DAMAGE", "RANDOM_DURATION" ],
+    "valid_targets": [ "hostile" ],
+    "effect_str": "poison",
+    "min_range": 1,
+    "max_range": 1,
+    "effect": "target_attack",
+    "min_duration": 500,
+    "max_duration": 1500,
+    "min_damage": 2,
+    "max_damage": 5,
+    "damage_type": "bio"
+  },
+  {
+    "type": "SPELL",
+    "id": "arcana_react_nothing",
+    "name": "React: Nothing",
+    "description": "Dirty hack to add RNG to react effects.",
+    "valid_targets": [ "self" ],
+    "flags": [ "SILENT" ],
+    "message": "",
+    "effect": "target_attack"
+  },
+  {
+    "type": "SPELL",
+    "id": "arcana_react_symbol_judgment_wonder",
+    "name": "React: Judgment",
+    "description": "Roll for zot!",
+    "valid_targets": [ "hostile" ],
+    "message": "",
+    "effect": "none",
+    "flags": [ "WONDER", "SILENT" ],
+    "min_damage": 1,
+    "max_damage": 1,
+    "extra_effects": [
+      { "id": "arcana_react_nothing" },
+      { "id": "arcana_react_nothing" },
+      { "id": "arcana_react_nothing" },
+      { "id": "arcana_react_nothing" },
+      { "id": "arcana_react_symbol_judgment_zap" }
+    ]
+  },
+  {
+    "id": "arcana_react_symbol_judgment_zap",
+    "type": "SPELL",
+    "name": "React: Electric Sting",
+    "description": "Zaps someone in melee.",
+    "message": "",
+    "flags": [ "RANDOM_DAMAGE", "RANDOM_DURATION" ],
+    "valid_targets": [ "hostile" ],
+    "effect_str": "zapped",
+    "sound_description": "a quiet electric crackle",
+    "min_range": 1,
+    "max_range": 1,
+    "effect": "target_attack",
+    "min_duration": 100,
+    "max_duration": 500,
+    "min_damage": 1,
+    "max_damage": 3,
+    "damage_type": "electric"
   }
 ]

--- a/Arcana/tool_armor.json
+++ b/Arcana/tool_armor.json
@@ -4,9 +4,19 @@
     "copy-from": "spell_base",
     "type": "TOOL_ARMOR",
     "name": "amber halo",
-    "description": "A strange radiance permeating your body, protecting you from lightning.",
+    "description": "A strange radiance permeating your body.  It will protect against electrical arcs, but only partially protect you against contact with electrified enemies.",
     "color": "light_gray",
-    "artifact_data": { "effects_worn": [ "AEP_RESIST_ELECTRICITY" ] },
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ALWAYS",
+          "values": [
+            { "value": "ARMOR_ELEC", "add": -5 }
+          ]
+        }
+      ]
+    },
     "flags": [ "ONLY_ONE" ]
   },
   {
@@ -105,13 +115,24 @@
     "copy-from": "somen_clairvoyance",
     "name": "mask of insight (on)",
     "name_plural": "masks of insight (on)",
-    "//": "It seems you need around 6 to protect against flashes",
     "description": "A mask faced with iron and decorated with other metal, depicting the face of some unknown divine figure.  The face depicted on the mask seems more menacing than it did previously.",
     "turns_per_charge": 300,
     "revert_to": "somen_clairvoyance",
     "material_thickness": 2,
     "environmental_protection": 6,
     "artifact_data": { "effects_worn": [ "AEP_CLAIRVOYANCE_PLUS" ] },
+    "//": "Clairvoyance in combat makes it slightly easier to read incoming attacks, ideally in the future this effect will factor into a combative style instead of benefiting untrained users.",
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ALWAYS",
+          "values": [
+            { "value": "BONUS_DODGE", "add": 1 }
+          ]
+        }
+      ]
+    },
     "qualities": [ [ "GLARE", 2 ] ],
     "use_action": {
       "target": "somen_clairvoyance",
@@ -255,7 +276,7 @@
   },
   {
     "id": "meteoric_talisman",
-    "type": "ARMOR",
+    "type": "TOOL_ARMOR",
     "name": "meteoric talisman",
     "category": "armor",
     "description": "An ornate necklace with a small charm resembling a round shield, made from a hard iridescent metal.  Wearing and activating it will ward against electricity, but also slow the body.",
@@ -267,6 +288,7 @@
     "looks_like": "jade_brooch",
     "color": "light_gray",
     "ammo": "essence_dull_type",
+    "initial_charges": 0,
     "max_charges": 20,
     "use_action": {
       "target": "meteoric_talisman_on",
@@ -282,10 +304,10 @@
   {
     "id": "meteoric_talisman_on",
     "copy-from": "meteoric_talisman",
-    "type": "ARMOR",
+    "type": "TOOL_ARMOR",
     "name": "meteoric talisman (active)",
     "name_plural": "meteoric talismans (active)",
-    "description": "An ornate necklace with a small charm resembling a round shield, made from a hard iridescent metal.  A strange electric tingle permeates the air around it, hinting at its protective magic.",
+    "description": "An ornate necklace with a small charm resembling a round shield, made from a hard iridescent metal.  A strange electric tingle permeates the air around it, hinting at its protective magic.  It will resist most contact with electricity, though powerful jolts may still harm you.",
     "turns_per_charge": 150,
     "revert_to": "meteoric_talisman",
     "use_action": {
@@ -293,7 +315,18 @@
       "msg": "The glow fades from the meteoric talisman, its protective magic fading with it.",
       "type": "transform"
     },
-    "artifact_data": { "effects_worn": [ "AEP_RESIST_ELECTRICITY", "AEP_SPEED_DOWN" ] }
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ALWAYS",
+          "values": [
+            { "value": "ARMOR_ELEC", "add": -10 },
+            { "value": "SPEED", "add": -20 }
+          ]
+        }
+      ]
+    }
   },
   {
     "id": "cleric_ring",


### PR DESCRIPTION
* Added a 1 in 5 chance of zapping a target when hitting them with a symbol of judgment.
* Added a poison effect to melee damage dealt with the bane staff.
* Overhauled how amber halo and meteoric talisman get their protection. Amber halo is now basically only good against electricity fields with slight resistance to melee zaps, while meteoric talisman gives increased protection that further reduces damage. Now the PoTV ward spell is the only source of complete immunity to lightning.
* Minor enchantment bonus when wearing an active mask of insight.
* Also fixed the meteoric talisman being basically unusable, now it reloads properly and can be turned on.
* Minor name length fix.