### PR TITLE
Mod Interaction: The Bone Seer

### DIFF
--- a/Arcana/TALK_BONE_SEER.json
+++ b/Arcana/TALK_BONE_SEER.json
@@ -33,7 +33,7 @@
     "dynamic_line": "I know not of what you ask.  I merely gather the bones to hear their song.  There are perhaps other verses to gather, but they can lead one astray.",
     "responses": [
       {
-        "text": "There is much I can teach, as recompense for the lesson you have taught me.  It is my master's wish that I spread His word.",
+        "text": "There is much I can teach, as recompense for the lesson you have taught me.  My master wishes that I spread His word.",
         "condition": { "u_has_trait": "THRESH_VEIL" },
         "switch": true,
         "topic": "TALK_BONE_SEER_POWER_CHALICE"
@@ -51,7 +51,7 @@
         "topic": "TALK_BONE_SEER_POWER_SANGUINE"
       },
       {
-        "text": "Look at me.  You have surely seen mutants before, but there is something deeper than that at work.  Power from beyond this world made me this way.",
+        "text": "Look at me.  You have surely seen mutants before, but there is something deeper than that here.  Power from beyond this world made me this way.",
         "condition": { "u_has_trait": "THRESH_DRAGONBLOOD" },
         "topic": "TALK_BONE_SEER_POWER_DRAGONBLOOD"
       },
@@ -92,7 +92,7 @@
     "dynamic_line": "Is that so?  I'm listening, then.",
     "responses": [
       {
-        "text": "What do you make of this?  It's a fang broken off from a monster that doesn't belong in this world, made of otherworldly crystal.",
+        "text": "What do you make of this?  It's a fang from a monster that doesn't belong in this world, made of otherworldly crystal.",
         "condition": { "u_has_item": "graboid_fang" },
         "topic": "TALK_BONE_SEER_POWER_OFFER_GRABOID_FANG"
       },
@@ -198,7 +198,7 @@
     "id": "TALK_BONE_SEER_POWER_MYRIAD",
     "dynamic_line": "Of that, I am sure even though I do not know their names.  But they are all beholden to the cycles that we are trapped in.",
     "responses": [
-      { "text": "I could show you something you might be able to learn from.", "topic": "TALK_BONE_SEER_POWER_POTENTIAL" },
+      { "text": "I could show you something you might be able to learn from.", "topic": "TALK_BONE_SEER_POWER_OFFER" },
       { "text": "Perhaps you're right.  We'll see, in time.", "topic": "TALK_BONE_SEER" }
     ]
   },
@@ -207,7 +207,7 @@
     "id": "TALK_BONE_SEER_POWER_CLEANSINGFLAME",
     "dynamic_line": "This is more than ritual.  You have heard the songs, haven't you?  What more do you need?",
     "responses": [
-      { "text": "I could show you something that might explain what I speak of.", "topic": "TALK_BONE_SEER_POWER_POTENTIAL" },
+      { "text": "I could show you something that might explain what I speak of.", "topic": "TALK_BONE_SEER_POWER_OFFER" },
       { "text": "Nevermind.  There's no point in arguing over it.", "topic": "TALK_DONE" }
     ]
   },
@@ -218,7 +218,7 @@
     "responses": [
       {
         "text": "There is something I could show you, that makes the power of your so-called song look like child's play.",
-        "topic": "TALK_BONE_SEER_POWER_POTENTIAL"
+        "topic": "TALK_BONE_SEER_POWER_OFFER"
       },
       {
         "text": "I have no time to spare for disproving your delusions.  I've nothing more to say to you.",
@@ -232,12 +232,12 @@
     "dynamic_line": "Whatever form your flesh takes, underneath your power is the same as it always has been.  As it always shall be.  No matter which face you bear, whose name you answer to, the bones are of the same substance.  From now, until this cycle is broken.",
     "responses": [
       {
-        "text": "I don't think my bones are the same as they were, given how different they are now, along with everything else.",
+        "text": "I don't think my bones are the same as they were, as different as they are now, along with everything else.",
         "topic": "TALK_BONE_SEER_POWER_DRAGONBLOOD_SMARTASS"
       },
       {
         "text": "But, there is something more to this.  I could show you.",
-        "topic": "TALK_BONE_SEER_POWER_POTENTIAL"
+        "topic": "TALK_BONE_SEER_POWER_OFFER"
       },
       {
         "text": "You know nothing of true power.  I have no interest in trying to talk you out of your folly.",
@@ -252,7 +252,7 @@
     "responses": [
       {
         "text": "Fine then.  But maybe I still have something that would prove my point.",
-        "topic": "TALK_BONE_SEER_POWER_POTENTIAL"
+        "topic": "TALK_BONE_SEER_POWER_OFFER"
       },
       { "text": "...", "topic": "TALK_BONE_SEER" }
     ]
@@ -262,7 +262,7 @@
     "id": "TALK_BONE_SEER_POWER_GENERAL",
     "dynamic_line": "Perhaps this is true.  But underneath the pollution that undeath brings, the bones still speak their songs.  It is harder for the inexperienced to decipher them, but their nature is fundamentally changed.  I'm curious though, what lesson do you think remains unlearned?",
     "responses": [
-      { "text": "I might have something that would explain things better.", "topic": "TALK_BONE_SEER_POWER_POTENTIAL" },
+      { "text": "I might have something that would explain things better.", "topic": "TALK_BONE_SEER_POWER_OFFER" },
       { "text": "Another time perhaps, I will need to think on this.", "topic": "TALK_BONE_SEER" }
     ]
   },
@@ -331,7 +331,7 @@
     "responses": [
       { "text": "You will find nothing but misery, pursuing this madness.  I will not stop you.", "topic": "TALK_DONE" },
       {
-        "text": "[ATTACK] I cannot allow you to continue pursuing this.  If there is any truth to your delusion, it will only bring more suffering.",
+        "text": "[ATTACK] I cannot allow you to continue this.  If there is any truth to your delusions, it will only bring more suffering.",
         "effect": "insult_combat",
         "topic": "TALK_DONE"
       }

--- a/Arcana/TALK_BONE_SEER.json
+++ b/Arcana/TALK_BONE_SEER.json
@@ -1,0 +1,377 @@
+[
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER",
+    "responses": [
+      {
+        "text": "What do you know of other practices, other strange powers?",
+        "topic": "TALK_BONE_SEER_POWER",
+        "condition": {
+          "and": [
+            { "u_has_trait": "seer_mark" },
+            {
+              "u_has_any_trait": [
+                "PROF_ARCANIST",
+                "PROF_ARCANIST2",
+                "PROF_CLEANSINGFLAME",
+                "PROF_CLEANSINGFLAME2",
+                "PROF_SANGUINE",
+                "PROF_CHALICE",
+                "THRESH_VEIL",
+                "THRESH_DRAGONBLOOD"
+              ]
+            },
+            { "not": { "u_has_var": "gave_monsterpart", "type": "dialogue", "context": "beyond", "value": "yes" } }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER",
+    "dynamic_line": "I know not of what you ask.  I merely gather the bones to hear their song.  There are perhaps other verses to gather, but they can lead one astray.",
+    "responses": [
+      {
+        "text": "There is much I can teach, as recompense for the lesson you have taught me.  It is my master's wish that I spread His word.",
+        "condition": { "u_has_trait": "THRESH_VEIL" },
+        "switch": true,
+        "topic": "TALK_BONE_SEER_POWER_CHALICE"
+      },
+      {
+        "text": "Morbid as your practice is, there is no actual magic in them.  This is a mere religious rite.",
+        "condition": { "u_has_any_trait": [ "PROF_CLEANSINGFLAME", "PROF_CLEANSINGFLAME2" ] },
+        "switch": true,
+        "topic": "TALK_BONE_SEER_POWER_CLEANSINGFLAME"
+      },
+      {
+        "text": "You seek power in life.  Whether it be bones, flesh, or blood, there are far greater truths to learn.",
+        "condition": { "u_has_trait": "PROF_SANGUINE" },
+        "switch": true,
+        "topic": "TALK_BONE_SEER_POWER_SANGUINE"
+      },
+      {
+        "text": "Look at me.  You have surely seen mutants before, but there is something deeper than that at work.  Power from beyond this world made me this way.",
+        "condition": { "u_has_trait": "THRESH_DRAGONBLOOD" },
+        "topic": "TALK_BONE_SEER_POWER_DRAGONBLOOD"
+      },
+      {
+        "text": "Perhaps there are other things to learn from studying the bones, especially of things touched by the Beyond.",
+        "topic": "TALK_BONE_SEER_POWER_GENERAL"
+      },
+      { "text": "Nevermind.  It's nothing.", "topic": "TALK_BONE_SEER" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER_CHALICE",
+    "dynamic_line": "I have my beliefs that I keep close to heart, but I will not deny you your vision.  So long as it does not impede my work.  What purpose do you pursue?",
+    "responses": [
+      { "text": "I would ask to show you the potential within The Beyond.", "topic": "TALK_BONE_SEER_POWER_POTENTIAL" },
+      {
+        "text": "Do you know of the powers from Beyond, that seek their myriad goals?",
+        "topic": "TALK_BONE_SEER_POWER_MYRIAD"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER_POTENTIAL",
+    "dynamic_line": "There is potential within many things, but few things hold the same permanence.  I know nothing of whatever it you seek, only that it is beholden to the cycle in ways that the bones are not.",
+    "responses": [
+      {
+        "text": "Perhaps I could show you something that would enlighten you, as you have enlightened me.",
+        "topic": "TALK_BONE_SEER_POWER_OFFER"
+      },
+      { "text": "So you claim.  Perhaps another time, I will show you the hidden truths.", "topic": "TALK_BONE_SEER" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER_OFFER",
+    "dynamic_line": "Is that so?  I'm listening, then.",
+    "responses": [
+      {
+        "text": "What do you make of this?  It's a fang broken off from a monster that doesn't belong in this world, made of otherworldly crystal.",
+        "condition": { "u_has_item": "graboid_fang" },
+        "topic": "TALK_BONE_SEER_POWER_OFFER_GRABOID_FANG"
+      },
+      {
+        "text": "What about this?  A fang torn from an otherworldly monster.",
+        "condition": { "u_has_item": "monster_fang" },
+        "topic": "TALK_BONE_SEER_POWER_OFFER_MONSTER_FANG"
+      },
+      {
+        "text": "These bones are a twisted knot of otherworldly presence.  Would this prove my point?",
+        "condition": { "u_has_item": "bone_twisted" },
+        "topic": "TALK_BONE_SEER_POWER_OFFER_BONE_TWISTED"
+      },
+      {
+        "text": "These are the finger bones of a creature touched by The Beyond.  Would that suffice?",
+        "condition": { "u_has_item": "gracken_knuckles" },
+        "topic": "TALK_BONE_SEER_POWER_OFFER_GRACKEN_KNUCKLES"
+      },
+      { "text": "I'm not sure what would be fitting.  Another time perhaps.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER_OFFER_GRABOID_FANG",
+    "dynamic_line": "How peculiar.  Normally I would consider this to be foolish, for what songs can stone sing?  But I can hear its whispers, it's like a song in another language, yet it sings like bones all the same.  I don't know how I could repay you for such a thing, but would you be willing to part with it?",
+    "responses": [
+      {
+        "text": "Go ahead.  It's yours.",
+        "effect": [
+          { "u_consume_item": "graboid_fang" },
+          { "u_add_var": "gave_monsterpart", "type": "dialogue", "context": "beyond", "value": "yes" }
+        ],
+        "topic": "TALK_BONE_SEER_POWER_STUDY"
+      },
+      { "text": "I can't part with it just yet.  I'm sorry.", "topic": "TALK_BONE_SEER_POWER_REFUSAL" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER_STUDY",
+    "dynamic_line": "Thank you.  I will need some time to gather its songs.  Perhaps you are correct, that there is more to this than what I have witnessed.  These verses are so far beyond my experience, there is surely great strength in them...",
+    "responses": [
+      { "text": "We still have much to discuss, if you don't mind.", "topic": "TALK_BONE_SEER" },
+      { "text": "You're welcome.  That's all for now, then.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER_REFUSAL",
+    "dynamic_line": "I see.  You have my curiosity, regardless.  Another time, then.  I need to hear what you have heard, see if there is merit in the verses these peculiar bones sing.",
+    "responses": [ { "text": "We shall see.", "topic": "TALK_BONE_SEER" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER_OFFER_MONSTER_FANG",
+    "dynamic_line": "Ivory, more transient and fleeting than bones, but aligned all the same.  I can hear the whispered verses though, this thing sings with a resonance I've never heard before.  If there is any truth to the strange things you've said, I must find out for myself.  Please, I don't thing I can repay you properly for this, but would you be willing to part with that?",
+    "responses": [
+      {
+        "text": "Go ahead.  It's yours.",
+        "effect": [
+          { "u_consume_item": "monster_fang" },
+          { "u_add_var": "gave_monsterpart", "type": "dialogue", "context": "beyond", "value": "yes" }
+        ],
+        "topic": "TALK_BONE_SEER_POWER_STUDY"
+      },
+      { "text": "I can't part with it just yet.  I'm sorry.", "topic": "TALK_BONE_SEER_POWER_REFUSAL" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER_OFFER_BONE_TWISTED",
+    "dynamic_line": "Even among the shambling undead, I have never seen such discord and strife within their bones.  You can practically read the verses etched into every tangled surface, what could create such a thing?  Please, you must give it to me.  I don't know if I could repay you for such a kindness...",
+    "responses": [
+      {
+        "text": "Go ahead.  It's yours.",
+        "effect": [
+          { "u_consume_item": "bone_twisted" },
+          { "u_add_var": "gave_monsterpart", "type": "dialogue", "context": "beyond", "value": "yes" }
+        ],
+        "topic": "TALK_BONE_SEER_POWER_STUDY"
+      },
+      { "text": "I can't part with it just yet.  I'm sorry.", "topic": "TALK_BONE_SEER_POWER_REFUSAL" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER_OFFER_GRACKEN_KNUCKLES",
+    "dynamic_line": "Ah, this is a very traditional manner of hearing the songs, of grasping the power within.  But these hum with verses I have never heard before.  Is this true, that there is something more to learn from these bones?  I cannot repay you for this, but please.  If you would be willing to part with them...",
+    "responses": [
+      {
+        "text": "Go ahead.  It's yours.",
+        "effect": [
+          { "u_consume_item": "gracken_knuckles" },
+          { "u_add_var": "gave_monsterpart", "type": "dialogue", "context": "beyond", "value": "yes" }
+        ],
+        "topic": "TALK_BONE_SEER_POWER_STUDY"
+      },
+      { "text": "I can't part with it just yet.  I'm sorry.", "topic": "TALK_BONE_SEER_POWER_REFUSAL" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER_MYRIAD",
+    "dynamic_line": "Of that, I am sure even though I do not know their names.  But they are all beholden to the cycles that we are trapped in.",
+    "responses": [
+      { "text": "I could show you something you might be able to learn from.", "topic": "TALK_BONE_SEER_POWER_POTENTIAL" },
+      { "text": "Perhaps you're right.  We'll see, in time.", "topic": "TALK_BONE_SEER" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER_CLEANSINGFLAME",
+    "dynamic_line": "This is more than ritual.  You have heard the songs, haven't you?  What more do you need?",
+    "responses": [
+      { "text": "I could show you something that might explain what I speak of.", "topic": "TALK_BONE_SEER_POWER_POTENTIAL" },
+      { "text": "Nevermind.  There's no point in arguing over it.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER_SANGUINE",
+    "dynamic_line": "I do not gather the strength in these bones, amass the Song, simply out of lust for power.  This is my duty, to gather the verses, together with my Kindred.",
+    "responses": [
+      {
+        "text": "There is something I could show you, that makes the power of your so-called song look like child's play.",
+        "topic": "TALK_BONE_SEER_POWER_POTENTIAL"
+      },
+      {
+        "text": "I have no time to spare for disproving your delusions.  I've nothing more to say to you.",
+        "topic": "TALK_DONE"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER_DRAGONBLOOD",
+    "dynamic_line": "Whatever form your flesh takes, underneath your power is the same as it always has been.  As it always shall be.  No matter which face you bear, whose name you answer to, the bones are of the same substance.  From now, until this cycle is broken.",
+    "responses": [
+      {
+        "text": "I don't think my bones are the same as they were, given how different they are now, along with everything else.",
+        "topic": "TALK_BONE_SEER_POWER_DRAGONBLOOD_SMARTASS"
+      },
+      {
+        "text": "But, there is something more to this.  I could show you.",
+        "topic": "TALK_BONE_SEER_POWER_POTENTIAL"
+      },
+      {
+        "text": "You know nothing of true power.  I have no interest in trying to talk you out of your folly.",
+        "topic": "TALK_DONE"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER_DRAGONBLOOD_SMARTASS",
+    "dynamic_line": "You think too literally of it.  If your way of thinking about it was true, then to lose a limb would make you of different substance.  Underneath it all, it is the song being sung which transcends your petty distinctions.",
+    "responses": [
+      {
+        "text": "Fine then.  But maybe I still have something that would prove my point.",
+        "topic": "TALK_BONE_SEER_POWER_POTENTIAL"
+      },
+      { "text": "...", "topic": "TALK_BONE_SEER" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_POWER_GENERAL",
+    "dynamic_line": "Perhaps this is true.  But underneath the pollution that undeath brings, the bones still speak their songs.  It is harder for the inexperienced to decipher them, but their nature is fundamentally changed.  I'm curious though, what lesson do you think remains unlearned?",
+    "responses": [
+      { "text": "I might have something that would explain things better.", "topic": "TALK_BONE_SEER_POWER_POTENTIAL" },
+      { "text": "Another time perhaps, I will need to think on this.", "topic": "TALK_BONE_SEER" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_END",
+    "responses": [
+      {
+        "text": "Perhaps this is true.  But what certainty do you have that any mortal hand can end this cycle?",
+        "condition": { "u_has_trait": "THRESH_VEIL" },
+        "topic": "TALK_BONE_SEER_CYCLE_PARAGON"
+      },
+      {
+        "text": "You speak a dangerous folly, destruction of the world.",
+        "condition": { "u_has_any_trait": [ "PROF_CLEANSINGFLAME", "PROF_CLEANSINGFLAME2" ] },
+        "topic": "TALK_BONE_SEER_CYCLE_CLEANSINGFLAME"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_CYCLE_PARAGON",
+    "dynamic_line": "I am not alone in this task.  No matter how many deaths my flesh endures, I will carry on my work.  As many times as it takes.  Interesting, however, that you speak as though there are things beyond mortal means, unfazed by the cycle.  The cycle is all-encompassing.  All that may live, whether or not they were ever born, is beholden to this.",
+    "responses": [
+      {
+        "text": "There is another who has assigned a task of great purpose.  Perhaps in time, our missions will align.",
+        "condition": { "u_has_trait": "seer_mark" },
+        "switch": true,
+        "topic": "TALK_BONE_SEER_CYCLE_PARAGON_MARKED"
+      },
+      {
+        "text": "I have a mission of my own, we'll see if it leads us down the same path.",
+        "switch": true,
+        "default": true,
+        "topic": "TALK_BONE_SEER_CYCLE_PARAGON_OTHER"
+      },
+      { "text": "We shall see if this holds true.", "topic": "TALK_BONE_SEER" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_CYCLE_PARAGON_MARKED",
+    "dynamic_line": {
+      "u_has_var": "gave_monsterpart",
+      "type": "dialogue",
+      "context": "beyond",
+      "value": "yes",
+      "no": "One day, in this flesh or in another cycle, we shall see.  Now, there is work I must tend to.",
+      "yes": "You have shown me fascinating verses within those peculiar bones, so we shall see.  I will listen to the Song that your present has offered me, and we'll see where it leads.  If your patron, whoever he may be, truly has the means to break the cycle, then perhaps this is his way of bringing this cycle to greater heights, to bring us closer to amassing the Song..."
+    },
+    "responses": [ { "text": "Very well.  We shall see.", "topic": "TALK_BONE_SEER" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_CYCLE_PARAGON_OTHER",
+    "dynamic_line": "I do not know what purpose you pursue this task, but I am reluctant to believe this.  There is much work to be done, and many false omens to lead us astray.",
+    "responses": [
+      { "text": "If you insist.  There is more to discuss, however.", "topic": "TALK_BONE_SEER" },
+      { "text": "So you say.  That is all for now, then.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_BONE_SEER_CYCLE_CLEANSINGFLAME",
+    "dynamic_line": "We cling to our lives, even knowing we have suffered a thousand deaths.  Only time will tell what future awaits us when this cycle is broken, but is it not better for us, that we be freed of this torment?",
+    "responses": [
+      { "text": "You will find nothing but misery, pursuing this madness.  I will not stop you.", "topic": "TALK_DONE" },
+      {
+        "text": "[ATTACK] I cannot allow you to continue pursuing this.  If there is any truth to your delusion, it will only bring more suffering.",
+        "effect": "insult_combat",
+        "topic": "TALK_DONE"
+      }
+    ]
+  },
+  {
+    "id": "TALK_MISSION_OFFER_SEER",
+    "type": "talk_topic",
+    "responses": [
+      {
+        "text": "This reeks of blood magic.  Do you even understand what you are asking of me?",
+        "condition": {
+          "and": [
+            { "u_has_any_trait": [ "PROF_CLEANSINGFLAME", "PROF_CLEANSINGFLAME2" ] },
+            {
+              "not": { "u_has_var": "blood_magic_query", "type": "dialogue", "context": "blood_magic", "value": "yes" }
+            }
+          ]
+        },
+        "topic": "TALK_MISSION_SEER_BLOOD_MAGIC"
+      }
+    ]
+  },
+  {
+    "id": "TALK_MISSION_SEER_BLOOD_MAGIC",
+    "type": "talk_topic",
+    "dynamic_line": "I suspect it is you who does not understand.  This is understandable, but this is why I offer you this chance to learn the verses the bones seek to sing.  I know not of what you called it, but this is not a thing of blood.  Blood is an impure thing, far too transient to offer worthy songs.  It is shed wantonly, and does not hold the permanence that bones carry with them.",
+    "//": "This is framed in such a way that it idiotproofs the dialogue, because TALK_NONE can potentially put you into a loop.",
+    "responses": [
+      {
+        "text": "If you insist, we'll see.  Explain again what you're asking of me.",
+        "topic": "TALK_MISSION_OFFER_SEER",
+        "effect": { "u_add_var": "blood_magic_query", "type": "dialogue", "context": "blood_magic", "value": "yes" }
+      },
+      { "text": "I need time to consider this.", "topic": "TALK_DONE" },
+      {
+        "text": "[ATTACK] You are treading dangerously close to things you do not truly understand.  I can't let you corrupt anyone else.  Ecce, sanguinem magum...",
+        "effect": "insult_combat",
+        "topic": "TALK_DONE"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Self-PRing to snag a bit of feedback, hopefully. This adds some dialogue to arcana specific to the NPC introduced in https://github.com/CleverRaven/Cataclysm-DDA/pull/33828, fleshing out interactions when the player-character has prior experience in the arcane.

* Characters with any of the notable arcanist traits (professions, as well as Paragons of The Veil and Dragonbloods) get some added dialogue after completing the bone seer's mission, which can lead to them potentially offering an arcane monsterpart. Just a bit of flavor dialogue that adds to their interaction, with the selection of parts that get an interesting response being specifically ones used to create a bone charm.
* Paragon of The Veil characters can muse on the nature of this implied cycle when the subject of ending it comes up, leading to more flavor dialogue between the two. This dialogue is also changed up a bit depending on whether or not they've completed the seer's mission, and whether or not they've given the seer a glimpse into the arcane.
* Mage hunters can respond with suspicion when the subject of potentially destroying the world comes up, allowing them to respond with hostility if they decide not to dismiss the seer's ideas as delusional.
* Mage hunters can also sidetrack the mission dialogue via accusing the seer of practicing blood magic, which the seer responds to with basically not really knowing what the hunter's on about, and
philosophizing about it instead. The player can either accept it and go back to pondering the mission, or react with hostility.

Pinging @SirPiecemaker to see if they have any feedback on this, and mainly because I'm hoping this isn't stepping on their toes a bit too much, and that the dialogue seems reasonably sensible for the bone seer to be saying. I'm not very good at dialogue writing. ._.