### PR TITLE
Implement forbidden_traits

### DIFF
--- a/Arcana/mutations.json
+++ b/Arcana/mutations.json
@@ -121,7 +121,6 @@
     "description": "You have been trained in Via Gladium et Malleo, a weapon art focused on preserving momentum and fighting multiple opponents, using your fury in different ways depending on your weapon of choice.",
     "starting_trait": true,
     "initial_ma_styles": [ "style_cleansingflame" ],
-    "changes_to": [ "PROF_SANGUINE", "PROF_CHALICE" ],
     "valid": false
   },
   {
@@ -481,7 +480,6 @@
     "valid": false,
     "purifiable": false,
     "category": [ "ECLIPSE" ],
-    "changes_to": [ "PROF_CLEANSINGFLAME", "PROF_CLEANSINGFLAME2" ],
     "spells_learned": [ [ "arcana_magic_eclipse", 1 ] ]
   },
   {
@@ -539,7 +537,6 @@
     "valid": false,
     "purifiable": false,
     "category": [ "HEAL" ],
-    "changes_to": [ "PROF_SANGUINE" ],
     "spells_learned": [ [ "arcana_magic_healing", 1 ] ]
   },
   {
@@ -631,7 +628,6 @@
     "purifiable": false,
     "//": "ID for INVIS retained to not break stuff.",
     "category": [ "INVIS" ],
-    "changes_to": [ "PROF_CLEANSINGFLAME", "PROF_CLEANSINGFLAME2" ],
     "spells_learned": [ [ "arcana_magic_serpentine_shield", 1 ] ]
   },
   {
@@ -655,7 +651,7 @@
     "valid": false,
     "purifiable": false,
     "category": [ "BUGSLESSER" ],
-    "changes_to": [ "PROF_CLEANSINGFLAME", "PROF_CLEANSINGFLAME2", "SPELL_BUGS", "SPELL_SUMMONVORTEX" ],
+    "changes_to": [ "SPELL_BUGS", "SPELL_SUMMONVORTEX" ],
     "spells_learned": [ [ "arcana_magic_summon_giant_centipedes", 1 ] ]
   },
   {
@@ -666,16 +662,7 @@
     "description": "Powers from beyond have granted you the power to summon a skeletal dog.  (( Remember to bind the \"spellcasting\" key! ))",
     "valid": false,
     "purifiable": false,
-    "changes_to": [
-      "PROF_CLEANSINGFLAME",
-      "PROF_CLEANSINGFLAME2",
-      "SPELL_SUMMONDOG2",
-      "SPELL_SUMMONSKEL",
-      "SPELL_SUMMONCULUS",
-      "SPELL_SUMMONTHING",
-      "SPELL_BUGS",
-      "SPELL_SUMMONVORTEX"
-    ],
+    "changes_to": [ "SPELL_SUMMONDOG2", "SPELL_SUMMONSKEL", "SPELL_SUMMONCULUS", "SPELL_SUMMONTHING", "SPELL_BUGS", "SPELL_SUMMONVORTEX" ],
     "spells_learned": [ [ "arcana_magic_summon_skeletal_dog", 1 ] ]
   },
   {
@@ -1677,9 +1664,7 @@
     "description": "You were sworn into an order known as the Cleansing Flame.  Whether a dutiful hunter or a renagade, wherever your loyalties now lie, your past may still be useful in the future.",
     "valid": false,
     "purifiable": false,
-    "profession": true,
-    "//": "This prevents mage hunters from picking forbidden summoning spells, along with blood magic.",
-    "cancels": [ "SPELL_SHADOWSNAKES", "SPELL_SUMMONDOG", "SPELL_BUGSLESSER", "SPELL_CLARITY", "SPELL_ECLIPSE" ]
+    "profession": true
   },
   {
     "type": "mutation",
@@ -1689,9 +1674,7 @@
     "description": "You were sworn into an order known as the Cleansing Flame.  Whether a dutiful hunter or a renagade, wherever your loyalties now lie, your past may still be useful in the future.",
     "valid": false,
     "purifiable": false,
-    "profession": true,
-    "//": "This prevents mage hunters from picking forbidden summoning spells, along with blood magic.",
-    "cancels": [ "SPELL_SHADOWSNAKES", "SPELL_SUMMONDOG", "SPELL_BUGSLESSER", "SPELL_CLARITY", "SPELL_ECLIPSE" ]
+    "profession": true
   },
   {
     "type": "mutation",
@@ -1701,9 +1684,7 @@
     "description": "You were sworn into an order known as the Sanguine Order.  Infamous and feared as you were among those who studied in secret, your past may still be useful in the future.",
     "valid": false,
     "purifiable": false,
-    "profession": true,
-    "//": "This prevents blood mages from picking a spell considered potentially too altruistic in nature, or from choosing a faction-specific martial art.  Non-faction arcanists are still allowed to pick it.",
-    "cancels": [ "SPELL_HEAL", "MARTIAL_ARTS_CF" ]
+    "profession": true
   },
   {
     "type": "mutation",
@@ -1713,9 +1694,7 @@
     "description": "You were sworn into an order known as the Keepers of The Oath.  Whether or not He From Beyond The Veil still guides you, the oath you swore is eternal, and your past may still be useful in the future.",
     "valid": false,
     "purifiable": false,
-    "profession": true,
-    "//": "This prevents dark priests from picking a faction-specific martial art.  Non-faction arcanists are still allowed to pick it.",
-    "cancels": [ "MARTIAL_ARTS_CF" ]
+    "profession": true
   },
   {
     "type": "mutation",

--- a/Arcana/professions.json
+++ b/Arcana/professions.json
@@ -46,6 +46,7 @@
       "female": [ "bra", "panties" ]
     },
     "traits": [ "PROF_ARCANIST" ],
+    "forbidden_traits": [ "ILLITERATE" ],
     "flags": [ "SCEN_ONLY" ]
   },
   {
@@ -78,6 +79,7 @@
       "female": [ "bra", "panties" ]
     },
     "traits": [ "PROF_ARCANIST" ],
+    "forbidden_traits": [ "ILLITERATE" ],
     "flags": [ "SCEN_ONLY" ]
   },
   {
@@ -108,6 +110,7 @@
       "female": [ "bra", "panties", "skirt" ]
     },
     "traits": [ "PROF_SANGUINE" ],
+    "forbidden_traits": [ "ILLITERATE", "SPIRITUAL", "PACIFIST", "SPELL_HEAL", "MARTIAL_ARTS_CF" ],
     "flags": [ "SCEN_ONLY" ]
   },
   {
@@ -148,6 +151,7 @@
       "female": [ "sports_bra", "boy_shorts" ]
     },
     "traits": [ "PROF_CLEANSINGFLAME" ],
+    "forbidden_traits": [ "ILLITERATE", "PACIFIST", "ARCANA_SCALYPATCHES", "ARCANA_INNERHEAT", "ARCANA_DRAGONCLAWS", "ARCANA_DRAGONTEETH", "ARCANA_DRAGONHORNS", "SPELL_SHADOWSNAKES", "SPELL_SUMMONDOG" ],
     "flags": [ "SCEN_ONLY" ]
   },
   {
@@ -180,6 +184,7 @@
       "female": [ "chestwrap" ]
     },
     "traits": [ "PROF_CHALICE" ],
+    "forbidden_traits": [ "ILLITERATE", "PACIFIST", "ARCANA_SCALYPATCHES", "ARCANA_INNERHEAT", "ARCANA_DRAGONCLAWS", "ARCANA_DRAGONTEETH", "ARCANA_DRAGONHORNS", "SPELL_SHADOWSNAKES", "MARTIAL_ARTS_CF" ],
     "flags": [ "SCEN_ONLY" ]
   },
   {
@@ -222,6 +227,7 @@
       "female": [ "bra", "panties" ]
     },
     "traits": [ "PROF_ARCANIST2" ],
+    "forbidden_traits": [ "ILLITERATE" ],
     "flags": [ "SCEN_ONLY" ]
   },
   {
@@ -276,6 +282,7 @@
       "female": [ "sports_bra", "boy_shorts" ]
     },
     "traits": [ "PROF_SANGUINE" ],
+    "forbidden_traits": [ "ILLITERATE", "PACIFIST", "MARTIAL_ARTS_CF" ],
     "flags": [ "SCEN_ONLY" ]
   },
   {
@@ -323,7 +330,7 @@
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boy_shorts" ]
     },
-    "traits": [ "PROF_CLEANSINGFLAME2" ],
+    "traits": [ "ILLITERATE", "PACIFIST", "PROF_CLEANSINGFLAME2" ],
     "flags": [ "SCEN_ONLY" ]
   },
   {
@@ -351,6 +358,7 @@
       "male": [ "boxer_briefs" ],
       "female": [ "bra", "panties" ]
     },
-    "traits": [ "PROF_ARCANIST" ]
+    "traits": [ "PROF_ARCANIST" ],
+    "forbidden_traits": [ "ILLITERATE", "HATES_BOOKS" ]
   }
 ]


### PR DESCRIPTION
* Removed overrides in mutation that made professions entirely preclude certain spell mutations.
* Implemented forbidden traits in professions to replace the above, so they correctly won't be available to specific professions in chargen, but they'll still be available in gameplay.
* Used the same means to deny professions certain lore-inappropriate traits in chargen, like Spiritual for blood mages (will still allow it for shrikes), Illiterate for most of the arcanists, etc.

Dependent on https://github.com/CleverRaven/Cataclysm-DDA/pull/36074 at present.

With thanks to @np-vortex, though I'm hoping the use of it in Arcana is correct syntax-wise, as the PR presently lacks documentation or a JSON example.