### PR TITLE
[WIP] Preparation for blood overhaul

### DIFF
--- a/Arcana/effects.json
+++ b/Arcana/effects.json
@@ -98,7 +98,7 @@
     "resist_effect": "talisman_warding",
     "desc": [ "Not immortality, but it still feels nice." ],
     "remove_message": "The healing effect fades.",
-    "removes_effects": [ "infected", "fungus", "bleed", "common_cold", "flu", "tetanus" ],
+    "removes_effects": [ "infected", "fungus", "bleed", "common_cold", "flu", "tetanus", "redcells_anemia", "hypovolemia" ],
     "decay_messages": [ [ "The soothing effect of your potion is starting to fade.", "bad" ] ],
     "rating": "good",
     "max_intensity": 15,
@@ -435,7 +435,7 @@
     "desc": [ "Unholy power fuels you, strengthening your body with an unnatural adrenaline surge." ],
     "remove_message": "You feel numb, hit with the sheer weight of the unnatural magic fading.",
     "decay_messages": [ [ "The blessing of the eclipse is waning.", "bad" ] ],
-    "blocks_effects": [ "bleed", "winded", "lack_sleep", "sleep" ],
+    "blocks_effects": [ "bleed", "winded", "lack_sleep", "sleep", "redcells_anemia", "hypovolemia" ],
     "rating": "good",
     "max_intensity": 100,
     "int_dur_factor": "1 m",
@@ -528,7 +528,7 @@
   {
     "type": "effect_type",
     "id": "arcane_healing_staunch",
-    "removes_effects": [ "bleed" ],
+    "removes_effects": [ "bleed", "redcells_anemia", "hypovolemia" ],
     "max_duration": "1 s"
   },
   {
@@ -615,13 +615,13 @@
   {
     "type": "effect_type",
     "id": "arcana_aegis_mending",
-    "blocks_effects": [ "bleed" ],
+    "blocks_effects": [ "bleed", "redcells_anemia", "hypovolemia" ],
     "rating": "good"
   },
   {
     "type": "effect_type",
     "id": "sword_mending",
-    "blocks_effects": [ "bleed", "winded" ],
+    "blocks_effects": [ "bleed", "winded", "redcells_anemia", "hypovolemia" ],
     "rating": "good",
     "max_duration": "15 s",
     "base_mods": { "pain_min": [ -5 ], "stamina_min": [ 500 ] }
@@ -823,7 +823,7 @@
     "id": "arcana_scroll_nature_effect",
     "//": "Explicitly punish Mycus players who will be immune to mutation, that's what you get for channeling a rival interloper's nature magic.",
     "resist_traits": [ "THRESH_MARLOSS", "THRESH_MYCUS" ],
-    "blocks_effects": [ "blind", "deaf", "infected", "bite", "bleed", "poison", "badpoison", "spores", "fungus" ],
+    "blocks_effects": [ "blind", "deaf", "infected", "bite", "bleed", "poison", "badpoison", "spores", "fungus", "redcells_anemia", "hypovolemia" ],
     "rating": "good",
     "base_mods": {
       "rad_min": [ -25, 25 ],

--- a/Arcana/items/comestibles.json
+++ b/Arcana/items/comestibles.json
@@ -96,7 +96,8 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the potion and feel a pleasant warmth spread through your body.",
-      "effects": [ { "id": "potion_healing", "duration": 900 } ]
+      "effects": [ { "id": "potion_healing", "duration": 900 } ],
+      "vitamins": [ [ "blood", 2500 ], [ "redcells", 2500 ] ]
     },
     "flags": [ "NO_INGEST", "EATEN_COLD", "NPC_SAFE", "NUTRIENT_OVERRIDE" ]
   },
@@ -124,7 +125,7 @@
       "limb_scaling": 2.7,
       "head_scaling": 2.7,
       "torso_scaling": 2.7,
-      "bleed": 1.0,
+      "bleed": 30,
       "bite": 0.95,
       "move_cost": 200,
       "effects": [ { "id": "potion_vulnerary", "duration": 300 } ]
@@ -219,7 +220,7 @@
       "limb_scaling": 1.0,
       "head_scaling": 1.0,
       "torso_scaling": 1.0,
-      "bleed": 0.5,
+      "bleed": 15,
       "bite": 0.5,
       "move_cost": 25,
       "effects": [ { "id": "talisman_warding", "duration": 600 } ]

--- a/Arcana/monsters/monsters.json
+++ b/Arcana/monsters/monsters.json
@@ -946,7 +946,6 @@
       "FIREPROOF",
       "FLIES",
       "POISON",
-      "BLEED",
       "REVIVES",
       "NO_BREATHE",
       "PRIORITIZE_TARGETS"
@@ -1441,7 +1440,6 @@
       "HARDTOSHOOT",
       "STUN_IMMUNE",
       "STUMBLES",
-      "BLEED",
       "PUSH_MON",
       "NO_BREATHE",
       "NOHEAD",
@@ -1488,7 +1486,6 @@
       "FLIES",
       "HARDTOSHOOT",
       "STUMBLES",
-      "BLEED",
       "NO_BREATHE",
       "NOHEAD"
     ]

--- a/Arcana/mutations/mutations_dragonblood.json
+++ b/Arcana/mutations/mutations_dragonblood.json
@@ -231,7 +231,8 @@
     "thirst_modifier": 0.5,
     "healing_awake": 1.0,
     "healing_resting": 0.5,
-    "stamina_regen_modifier": 0.5
+    "stamina_regen_modifier": 0.5,
+    "vitamin_rates": [ [ "blood", 1 ], [ "redcells", 1 ] ]
   },
   {
     "type": "mutation",
@@ -254,7 +255,8 @@
     "healing_awake": 2.0,
     "healing_resting": 1.0,
     "stamina_regen_modifier": 0.666,
-    "social_modifiers": { "persuade": -25, "intimidate": 25 }
+    "social_modifiers": { "persuade": -25, "intimidate": 25 },
+    "vitamin_rates": [ [ "blood", 2 ], [ "redcells", 2 ] ]
   },
   {
     "type": "mutation",
@@ -281,7 +283,8 @@
     "active": true,
     "cost": 30,
     "hunger": true,
-    "ranged_mutation": { "type": "mut_dragonfire", "message": "You loose a tongue of flame from your mouth." }
+    "ranged_mutation": { "type": "mut_dragonfire", "message": "You loose a tongue of flame from your mouth." },
+    "vitamin_rates": [ [ "blood", 3 ], [ "redcells", 3 ] ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
Preparation for https://github.com/CleverRaven/Cataclysm-DDA/pull/41219

* Set it so that red potion's effect blocks the extra effects of blood loss, and consuming it gives a hefty dose of blood and red blood cells.
* Updated medical items so that they reduce bleeding at expected rates.
* Set various effects that halt bleeding to also disrupt anemia and hypovolemic shock. In practice though, since there's no way for spells or effects to generate vitamins, I suspect this won't be as useful as halting blood loss would be.
* Set it so that Dragonblood mutants gain bonuses to blood recovery, scaling up as their main metabolic traits evolve (since those are the ones that affect healing rate)
* Removed use of oboslete monster flag.