### PR TITLE
Update recipe_ammo.json

### DIFF
--- a/Arcana/recipes/recipe_ammo.json
+++ b/Arcana/recipes/recipe_ammo.json
@@ -151,7 +151,7 @@
     "autolearn": true,
     "book_learn": [ [ "book_magicfordummies", 4 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "arrow_arcana_unpowered", 5 ] ], [ [ "earth_talisman", 1 ] ] ]
+    "components": [ [ [ "arrow_arcana_unpowered", 5 ] ], [ [ "air_talisman", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
arrow_arcana_air recipe erroneously assigned earth talisman component.
assigned air talisman component to arrow_arcana_air recipe.