### PR TITLE
Bolstered Iridescent Brooch Recipe Fix

### DIFF
--- a/Arcana_BN/recipes/recipe_armor.json
+++ b/Arcana_BN/recipes/recipe_armor.json
@@ -114,7 +114,7 @@
     "book_learn": [ [ "book_magicfordummies", 0 ] ],
     "using": [ [ "arcana_scrollwriting_rewrite", 1 ] ],
     "components": [
-      [ [ "amulet_exotic", 1 ] ],
+      [ [ "brooch_iridescent", 1 ] ],
       [ [ "earth_talisman", 1 ] ],
       [ [ "air_talisman", 1 ] ]
     ],


### PR DESCRIPTION
Bolstered Iridescent Brooch ("brooch_iridescent_empowered") currently uses Exotic Amulet as an ingredient instead of Iridescent Brooch. This code change proposes to substitute the latter, more intuitive ingredient in its recipe.