### PR TITLE
Add mod-compatibility monsterdrops for Cata++ monsters

### DIFF
--- a/Arcana/modinfo.json
+++ b/Arcana/modinfo.json
@@ -5,7 +5,7 @@
     "name": "Arcana and Magic Items",
     "authors": [ "Chaosvolt" ],
     "description": "Adds a new skill for creating and using magical items, and alters many anomalous monsters.",
-    "version": "DDA version, update 6/15/2021",
+    "version": "DDA version, update 6/21/2021",
     "category": "content",
     "dependencies": [ "dda" ]
   }

--- a/Arcana/monsters/monster_drops.json
+++ b/Arcana/monsters/monster_drops.json
@@ -1505,5 +1505,123 @@
       { "item": "essence_dull", "count": [ 0, 410 ] },
       { "item": "essence_pure", "count": [ 0, 5 ] }
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_weapom_item",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "bone_twisted", "prob": 50 },
+          { "item": "vortex_shard", "prob": 25 },
+          { "item": "wyrmskin_piece", "prob": 25 }
+        ],
+        "prob": 30
+      },
+      { "item": "essence_blood", "count": [ 1, 3 ], "prob": 15 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_fungus_failed_weapon_death_drops",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "bone_twisted", "prob": 50 },
+          { "item": "vortex_shard", "prob": 25 },
+          { "item": "wyrmskin_piece", "prob": 25 }
+        ],
+        "prob": 10
+      },
+      {
+        "distribution": [ { "item": "dermatik_sting", "prob": 50 }, { "item": "inflorescent_root", "prob": 50 } ],
+        "prob": 20
+      },
+      {
+        "distribution": [ { "item": "essence", "prob": 50 }, { "item": "essence_blood", "prob": 50, "count": [ 1, 3 ] } ],
+        "prob": 20
+      }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "apophis_bio_weapom_item",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "bone_twisted", "prob": 20 },
+          { "item": "vortex_shard", "prob": 20 },
+          { "item": "wyrmskin_piece", "prob": 20 },
+          { "item": "gracken_knuckles", "prob": 20 },
+          { "item": "iridescent_plate", "prob": 20 }
+        ]
+      },
+      {
+        "distribution": [ { "item": "essence", "count": [ 2, 5 ] }, { "item": "essence_blood", "count": [ 6, 15 ] } ]
+      }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_zombie_bio_dormant_unarmed_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 10 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_zombie_bio_dormant_armed_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 10 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_zombie_bio_knife_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_infantry_rifle",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_infantry_shotgun",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_knight_lmg",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_knight_launcher",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_scout_sniper",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_tool_pistol",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_tool_smg",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
   }
 ]

--- a/Arcana/monsters/monster_drops.json
+++ b/Arcana/monsters/monster_drops.json
@@ -1568,13 +1568,7 @@
     "type": "item_group",
     "id": "mon_zombie_bio_dormant_unarmed_death_drops",
     "subtype": "collection",
-    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 10 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "mon_zombie_bio_dormant_armed_death_drops",
-    "subtype": "collection",
-    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 10 } ]
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
   },
   {
     "type": "item_group",

--- a/Arcana_BN/modinfo.json
+++ b/Arcana_BN/modinfo.json
@@ -5,7 +5,7 @@
     "name": "Arcana and Magic Items",
     "authors": [ "Chaosvolt" ],
     "description": "Adds a new skill for creating and using magical items, and alters many anomalous monsters.",
-    "version": "BN version, update 6/15/2021",
+    "version": "BN version, update 6/21/2021",
     "category": "content",
     "dependencies": [ "dda" ]
   }

--- a/Arcana_BN/monsters/monster_drops.json
+++ b/Arcana_BN/monsters/monster_drops.json
@@ -1365,5 +1365,123 @@
     "id": "mon_zombie_medical_death_drops",
     "subtype": "collection",
     "entries": [ { "item": "iron_thorn", "prob": 10 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_weapom_item",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "bone_twisted", "prob": 50 },
+          { "item": "vortex_shard", "prob": 25 },
+          { "item": "wyrmskin_piece", "prob": 25 }
+        ],
+        "prob": 30
+      },
+      { "item": "essence_blood", "count": [ 1, 3 ], "prob": 15 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_fungus_failed_weapon_death_drops",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "bone_twisted", "prob": 50 },
+          { "item": "vortex_shard", "prob": 25 },
+          { "item": "wyrmskin_piece", "prob": 25 }
+        ],
+        "prob": 10
+      },
+      {
+        "distribution": [ { "item": "dermatik_sting", "prob": 50 }, { "item": "inflorescent_root", "prob": 50 } ],
+        "prob": 20
+      },
+      {
+        "distribution": [ { "item": "essence", "prob": 50 }, { "item": "essence_blood", "prob": 50, "count": [ 1, 3 ] } ],
+        "prob": 20
+      }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "apophis_bio_weapom_item",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "bone_twisted", "prob": 20 },
+          { "item": "vortex_shard", "prob": 20 },
+          { "item": "wyrmskin_piece", "prob": 20 },
+          { "item": "gracken_knuckles", "prob": 20 },
+          { "item": "iridescent_plate", "prob": 20 }
+        ]
+      },
+      {
+        "distribution": [ { "item": "essence", "count": [ 2, 5 ] }, { "item": "essence_blood", "count": [ 6, 15 ] } ]
+      }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_zombie_bio_dormant_unarmed_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 10 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_zombie_bio_dormant_armed_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 10 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_zombie_bio_knife_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_infantry_rifle",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_infantry_shotgun",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_knight_lmg",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_knight_launcher",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_scout_sniper",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_tool_pistol",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "wild_bio_tool_smg",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
   }
 ]

--- a/Arcana_BN/monsters/monster_drops.json
+++ b/Arcana_BN/monsters/monster_drops.json
@@ -1428,13 +1428,7 @@
     "type": "item_group",
     "id": "mon_zombie_bio_dormant_unarmed_death_drops",
     "subtype": "collection",
-    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 10 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "mon_zombie_bio_dormant_armed_death_drops",
-    "subtype": "collection",
-    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 10 } ]
+    "entries": [ { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
   },
   {
     "type": "item_group",


### PR DESCRIPTION
Self-PR'd so I'd be able to chuck it at Noct to see what they think of it.

* Set it so that augmented abominations, living or undead, can potentially drop blood essence. Both also have a chance of dropping a twisted bone, a wind fragment, or an acrid fragment.
* Fungal augmented abominations get a separate itemgroup injection that changes up the essence drop to randomly being either normal essence or blood essence (standardized for fungalized monsters by https://github.com/chaosvolt/cdda-arcana-mod/commit/28a3d50576020f4d5a3591d45b84559b969b1457), and a reduced chance of dropping the normal abomination monsterpart, in exchange for a second roll to potentially drop either a barbed stinger or an inflorescent root (common fungal creature drops).
* Set Apophis to drop boss-level amount of essence and a random monsterpart. DMs with Noct led to them suggesting that Apophis is exotic enough, via some integration with blob contamination from their mutations, to warrant dropping normal essence. For now I've gone with them randomly selecting either normal essence or blood essence. Their monsterpart selection can be a twisted bone, a wind fragment, an acrid fragment, cracked knucklebones, or an iridescent plate.
* Gave augmented undead soldiers a chance of dropping blood essence.

Fungal augmented abominations having a separate death drop itemgroup will require https://github.com/Noctifer-de-Mortem/nocts_cata_mod/pull/277 to work, otherwise they'll just drop the same things as normal abominations.

I might later on go back and set a few of the weird vanilla mutant monsters to do the same "either normal essence or blood essence" thing Apophis is set to, for a few monsters are are technically mutants but being used like abberations or horrors based on where they spawn. The first and foremost examples being dark wyrms, they're mutants that only spawn in mines when basically every other monster unique to mines is implied to be some weird otherworldly horror that slipped through the cracks in the Veil some time before the cataclysm.