### PR TITLE
Additions to the Urban Awakening Scenario and its professions.

### DIFF
--- a/Arcana_BN/chargen/professions.json
+++ b/Arcana_BN/chargen/professions.json
@@ -353,7 +353,7 @@
     "skills": [
       { "level": 4, "name": "magic" },
       { "level": 3, "name": "gun" },
-	  { "level": 3, "name": "melee" },
+      { "level": 3, "name": "melee" },
       { "level": 3, "name": "dodge" },
       { "level": 2, "name": "pistol" },
       { "level": 2, "name": "rifle" },
@@ -365,17 +365,17 @@
     "items": {
       "both": {
         "items": [ 
-		  "knit_scarf",
-		  "longshirt",
-		  "gloves_fingerless",
-		  "pants_cargo",
-		  "socks",
-		  "boots_combat",
-		  "trenchcoat",
-		  "molle_pack",
-		  "wristwatch",
-		  "smart_phone",
-		  "book_hexenhammer"
+          "knit_scarf",
+          "longshirt",
+          "gloves_fingerless",
+          "pants_cargo",
+          "socks",
+          "boots_combat",
+          "trenchcoat",
+          "molle_pack",
+          "wristwatch",
+          "smart_phone",
+          "book_hexenhammer"
 		],
         "entries": [
           { "item": "ethereal_crossbow", "charges": 20, "container-item": "shoulder_strap" },

--- a/Arcana_BN/chargen/professions.json
+++ b/Arcana_BN/chargen/professions.json
@@ -8,8 +8,8 @@
   {
     "type": "item_group",
     "subtype": "collection",
-    "id": "bandolier_shotgun_shot_00",
-    "entries": [ { "item": "shot_00", "charges": 25 } ]
+    "id": "bandolier_shotgun_shot_00_arcana",
+    "entries": [ { "item": "reloaded_shot_00_arcana", "charges": 25 } ]
   },
   {
     "type": "profession",
@@ -353,7 +353,8 @@
   {
     "type": "profession",
     "ident": "arcanist_operator",
-    "name": "Arcane Operator",
+    "name": "Arcane Operative",
+    "description": "You have embraced modern technology and mystical power alike, armed and augmented to investigate anomalies, procure artifacts, and help ensure the arcane stayed hidden from everyday life.  Once of the Cleansing Flame, whether you went rogue or still honor their ideals, you must use what you've learned to survive.",
     "description": "Your mission was simple, assure the arcane stayed hidden from everyday life. You were augmented, trained and armed to find arcane artifacts, prevent their missuse and silence anyone who would threatened your mission.  Once of the Cleansing Flame, whether you went rogue or still honor their ideals, you went your own path seeking the tools to aid in your path. You found them and now you must use them to survive.",
     "spells": [ { "id": "arcana_magic_capacitance", "level": 1 } ],
     "points": 12,
@@ -402,7 +403,7 @@
         "entries": [
           { "item": "ethereal_crossbow", "charges": 20, "container-item": "shoulder_strap" },
           { "item": "v29", "container-item": "XL_holster" },
-          { "item": "bandolier_shotgun", "contents-group": "bandolier_shotgun_shot_00" }
+          { "item": "bandolier_shotgun", "contents-group": "bandolier_shotgun_shot_00_arcana" }
         ]
       },
       "male": [ "boxer_briefs" ],

--- a/Arcana_BN/chargen/professions.json
+++ b/Arcana_BN/chargen/professions.json
@@ -6,6 +6,12 @@
     "entries": [ { "item": "flintlock_ammo", "charges": 14 } ]
   },
   {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "bandolier_shotgun_shot_00",
+    "entries": [ { "item": "shot_00", "charges": 25 } ]
+  },
+  {
     "type": "profession",
     "id": "arcanist_apprentice",
     "name": "Apprentice",
@@ -294,18 +300,17 @@
     "description": "You have embraced modern technology and mystical power alike, in your pursuit of knowledge and a way to prevent the cataclysm.  Once of the Cleansing Flame, whether you went rogue or still honor their ideals, that no longer matters anymore.",
     "spells": [ { "id": "arcana_magic_capacitance", "level": 1 } ],
     "points": 8,
-    "CBMs": [ "bio_lockpick", "bio_fingerhack", "bio_ups", "bio_batteries", "bio_metabolics", "bio_power_storage_mkII" ],
+    "CBMs": [ "bio_lockpick", "bio_fingerhack", "bio_ups", "bio_flashlight", "bio_tools", "bio_batteries", "bio_watch", "bio_power_storage_mkII" ],
     "skills": [
       { "level": 4, "name": "magic" },
+      { "level": 3, "name": "cooking" },
       { "level": 3, "name": "gun" },
-      { "level": 3, "name": "pistol" },
+      { "level": 3, "name": "melee" },
+      { "level": 2, "name": "pistol" },
       { "level": 2, "name": "computer" },
       { "level": 2, "name": "electronics" },
-      { "level": 2, "name": "speech" },
-      { "level": 2, "name": "melee" },
-      { "level": 1, "name": "cutting" },
-      { "level": 1, "name": "survival" },
-      { "level": 1, "name": "mechanics" }
+      { "level": 2, "name": "cutting" },
+      { "level": 2, "name": "fabrication" }
     ],
     "items": {
       "both": {
@@ -324,6 +329,7 @@
           "book_hexenhammer"
         ],
         "entries": [
+          { "item": "ethereal_hand_crossbow", "container-item": "XL_holster", "charges": 20 },
           { "item": "v29", "container-item": "XL_holster" },
           { "item": "sun_sword", "charges": 20, "container-item": "scabbard" },
           { "item": "medium_battery_cell", "charges": 500 }
@@ -331,6 +337,54 @@
       },
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boy_shorts" ]
+    },
+    "traits": [ "PROF_CLEANSINGFLAME2" ],
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
+    "ident": "arcanist_operator",
+    "name": "Arcane Operator",
+    "description": "Your mission was simple, assure the arcane stayed hidden from everyday life. You were augmented, trained and armed to find arcane artifacts, prevent their missuse and silence anyone who would threatened your mission.  Once of the Cleansing Flame, whether you went rogue or still honor their ideals, you went your own path seeking the tools to aid in your path. You found them and now you must use them to survive.",
+    "spells": [ { "id": "arcana_magic_capacitance", "level": 1 } ],
+	"points": 12,
+    "CBMs": [ "bio_targeting", "bio_cqb", "bio_shotgun", "bio_blade", "bio_shock", "bio_carbon", "bio_adrenaline", "bio_night_vision", "bio_lockpick", "bio_fingerhack", "bio_ups", "bio_metabolics", "bio_power_storage_mkII"
+    ],
+    "skills": [
+      { "level": 4, "name": "magic" },
+      { "level": 3, "name": "gun" },
+	  { "level": 3, "name": "melee" },
+      { "level": 3, "name": "dodge" },
+      { "level": 2, "name": "pistol" },
+      { "level": 2, "name": "rifle" },
+      { "level": 2, "name": "shotgun" },
+      { "level": 2, "name": "unarmed" },
+      { "level": 2, "name": "cutting" },
+      { "level": 2, "name": "computer" }
+    ],
+    "items": {
+      "both": {
+        "items": [ 
+		  "knit_scarf",
+		  "longshirt",
+		  "gloves_fingerless",
+		  "pants_cargo",
+		  "socks",
+		  "boots_combat",
+		  "trenchcoat",
+		  "molle_pack",
+		  "wristwatch",
+		  "smart_phone",
+		  "book_hexenhammer"
+		],
+        "entries": [
+          { "item": "ethereal_crossbow", "charges": 20, "container-item": "shoulder_strap" },
+          { "item": "v29", "container-item": "XL_holster" },
+          { "item": "bandolier_shotgun", "contents-group": "bandolier_shotgun_shot_00" }
+        ]
+      },
+      "male": [ "boxer_briefs" ],
+      "female": [ "bra", "panties" ]
     },
     "traits": [ "PROF_CLEANSINGFLAME2" ],
     "flags": [ "SCEN_ONLY" ]

--- a/Arcana_BN/chargen/professions.json
+++ b/Arcana_BN/chargen/professions.json
@@ -376,7 +376,7 @@
           "wristwatch",
           "smart_phone",
           "book_hexenhammer"
-		],
+        ],
         "entries": [
           { "item": "ethereal_crossbow", "charges": 20, "container-item": "shoulder_strap" },
           { "item": "v29", "container-item": "XL_holster" },

--- a/Arcana_BN/chargen/professions.json
+++ b/Arcana_BN/chargen/professions.json
@@ -300,7 +300,16 @@
     "description": "You have embraced modern technology and mystical power alike, in your pursuit of knowledge and a way to prevent the cataclysm.  Once of the Cleansing Flame, whether you went rogue or still honor their ideals, that no longer matters anymore.",
     "spells": [ { "id": "arcana_magic_capacitance", "level": 1 } ],
     "points": 8,
-    "CBMs": [ "bio_lockpick", "bio_fingerhack", "bio_ups", "bio_flashlight", "bio_tools", "bio_batteries", "bio_watch", "bio_power_storage_mkII" ],
+    "CBMs": [
+      "bio_lockpick",
+      "bio_fingerhack",
+      "bio_ups",
+      "bio_flashlight",
+      "bio_tools",
+      "bio_batteries",
+      "bio_watch",
+      "bio_power_storage_mkII"
+    ],
     "skills": [
       { "level": 4, "name": "magic" },
       { "level": 3, "name": "cooking" },
@@ -347,8 +356,21 @@
     "name": "Arcane Operator",
     "description": "Your mission was simple, assure the arcane stayed hidden from everyday life. You were augmented, trained and armed to find arcane artifacts, prevent their missuse and silence anyone who would threatened your mission.  Once of the Cleansing Flame, whether you went rogue or still honor their ideals, you went your own path seeking the tools to aid in your path. You found them and now you must use them to survive.",
     "spells": [ { "id": "arcana_magic_capacitance", "level": 1 } ],
-	"points": 12,
-    "CBMs": [ "bio_targeting", "bio_cqb", "bio_shotgun", "bio_blade", "bio_shock", "bio_carbon", "bio_adrenaline", "bio_night_vision", "bio_lockpick", "bio_fingerhack", "bio_ups", "bio_metabolics", "bio_power_storage_mkII"
+    "points": 12,
+    "CBMs": [
+      "bio_targeting",
+      "bio_cqb",
+      "bio_shotgun",
+      "bio_blade",
+      "bio_shock",
+      "bio_carbon",
+      "bio_adrenaline",
+      "bio_night_vision",
+      "bio_lockpick",
+      "bio_fingerhack",
+      "bio_ups",
+      "bio_metabolics",
+      "bio_power_storage_mkII"
     ],
     "skills": [
       { "level": 4, "name": "magic" },
@@ -364,7 +386,7 @@
     ],
     "items": {
       "both": {
-        "items": [ 
+        "items": [
           "knit_scarf",
           "longshirt",
           "gloves_fingerless",

--- a/Arcana_BN/chargen/scenarios.json
+++ b/Arcana_BN/chargen/scenarios.json
@@ -60,7 +60,7 @@
       "arcanist_scribe",
       "arcanist_shrike",
       "arcanist_purifier",
-	  "arcanist_operator"
+      "arcanist_operator"
     ],
     "traits": [
       "SPELL_CLAIRVOYANCE",

--- a/Arcana_BN/chargen/scenarios.json
+++ b/Arcana_BN/chargen/scenarios.json
@@ -59,7 +59,8 @@
       "arcanist_alchemist",
       "arcanist_scribe",
       "arcanist_shrike",
-      "arcanist_purifier"
+      "arcanist_purifier",
+	  "arcanist_operator"
     ],
     "traits": [
       "SPELL_CLAIRVOYANCE",


### PR DESCRIPTION
This PR changes the profession Arcane Purifier and add the Arcane Operator profession. Changed and additions are as follows:

Arcane Purifier - Changed made took into consideration two things, a point cost of 8 and the fact that this profession is tied to the Urban Awakening scenario which limits its starting options. Removed the bionic metabolics cbm making this profession dependent on batteries and it's capacitance spell; running out of bionic energy mid fight is a possibility now and was added to address other changed. Gave it both the Bionic toolset and the Bionic internal clock. Both give flavor to what this profession is and make it distinct from the other, the watch is just for flavor than use. gave it the bionic cranial flashlight to allow it to craft in a pinch, useful for being able to do thing in the field or under not so great conditions. Reworked their skill set; survival, mechanics and speech was removed and in favor fabrication and cooking was added so this profession could start with being able to take advantage of it's capabilities from the start. Added the pistol wraithslayer crossbow; the laser pistol is too weak to serve as a proper ranged weapon and in gameplay it serves as only something to use to aid your escape but it still fits their flavor. Added the crossbow since it also fits thematically and doesn't dramatically buff the profession.

Arcane Operator - This one is more combat focused, it has decent skill sets and armament to be able to tackle dangerous arcane locations. Knows enough about the arcane to be useful but most things are still looked away compared to the Arcane Purifier. The pistol and bionic shotgun are both fallbacks as this profession cannot resupply it's ammo and essence as easily as the Arcane Purifier, the bionic metabolics was added instead of the battery system to help this as well. This one has little in the way of arcane capabilities at the start so you will have to seek out artifacts and learn how to use them. Point cost was determine by both it's similarities and differences to the Arcane Purifier and also by it being locked away under the Urban Awakening Scenario which also locks places to look for artifacts right way and make them have to fight their way out to find them in the middle of a city; even the arcane basements do not give too much in the ways of artifacts since this profession can not make use of their supplies until they found more supplies.