### PR TITLE
Fix cyclopean mirror for DDA branch

### DIFF
--- a/Arcana/items/tool_armor.json
+++ b/Arcana/items/tool_armor.json
@@ -476,6 +476,7 @@
     "price_postapoc": "90 USD",
     "bashing": 8,
     "material": [ "iron" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 25 } } ],
     "symbol": "[",
     "looks_like": "shield_round",
     "color": "light_gray",


### PR DESCRIPTION
Cyclopean mirror lacks pocket data in DDA, so essence can't be loaded into it. Used BN max charges for ammo amount.