### PR TITLE
Add license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,1 @@
+Arcana is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/ or send a letter to Creative Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.


### PR DESCRIPTION
Arcana was a mod included in the DDA repo, and thus is a derivative work, under the CC-BY-SA 3.0 license DDA uses.
Included in DDA in this PR:
https://github.com/CleverRaven/Cataclysm-DDA/pull/13497

BN is also licensed under CC-BY-SA 3.0, so this will work for both repos.