### PR TITLE
Use "null" vitamin for mutation categories.

### DIFF
--- a/Arcana/mutations/mutation_category.json
+++ b/Arcana/mutations/mutation_category.json
@@ -5,7 +5,8 @@
     "threshold_mut": "THRESH_VEIL",
     "name": "Explorer of The Veil",
     "mutagen_message": "You feel an otherworldly presence reaching out to you.",
-    "memorial_message": "Pierced the veil between worlds."
+    "memorial_message": "Pierced the veil between worlds.",
+	"vitamin": "null"
   },
   {
     "id": "DRAGONBLOOD",
@@ -13,6 +14,7 @@
     "threshold_mut": "THRESH_DRAGONBLOOD",
     "name": "Acolyte of the Sacrament",
     "mutagen_message": "You feel a powerful resonance throughout your body, another irreversible step down the Path to Power.",
-    "memorial_message": "Gained power from the Dragonblood Sacrament."
+    "memorial_message": "Gained power from the Dragonblood Sacrament.",
+	"vitamin": "null"
   }
 ]


### PR DESCRIPTION
Without this, C:DDA will try look for the empty ("") vitamin and mutation will never occur since it doesn't exist in the player. The null vitamin bypasses that check.

Tested with Blood Effigy, Sacramental Heart, and Restored Ritual Blade.