### PR TITLE
Update tools.json. Make active Candle of Warding a firestarter

### DIFF
--- a/Arcana/items/tools.json
+++ b/Arcana/items/tools.json
@@ -1645,9 +1645,10 @@
         "menu_text": "Extinguish candle of warding",
         "type": "transform"
       },
+	  { "type": "firestarter", "moves": 100 },
       { "type": "deploy_furn", "furn_type": "f_candle_barrier_playermade" }
     ],
-    "flags": [ "NO_SALVAGE", "LIGHT_12" ]
+    "flags": [ "NO_SALVAGE", "LIGHT_12", "FIRESTARTER" ]
   },
   {
     "id": "transmutation_crucible",


### PR DESCRIPTION
Make Candle of Warding capable of lighting fires by action and light fires in furniture such as Smoking racks

Alternatives Considered:

That the Candle of Warding has a magical light that gives no heat and can create to no other flame. In which case ignore this