### PR TITLE
Fix VeilBlade AKA Restored Ritual Blade recipes book requirements

### DIFF
--- a/Arcana/recipes/recipe_weapon.json
+++ b/Arcana/recipes/recipe_weapon.json
@@ -576,7 +576,8 @@
     "using": [ [ "arcana_purification_standard", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "tools": [
-      [ [ "book_sacrifice", -1 ], [ "book_bloodmagic", -1 ], [ "book_syncretism", -1 ] ],
+      [ [ "book_sacrifice", -1 ] ],
+      [ [ "book_bloodmagic", -1 ] ],
       [
         [ "holy_symbol", -1 ],
         [ "holy_symbol_wood", -1 ],


### PR DESCRIPTION
Summary:
Change VeilBlade recipe to require both Oaths to The Chalice AND Sanguine Codex

Purpose of Change:
In the Blade Purification quest, the Hermit says that:
>The main things you will need are His sacred word, Oaths to The Chalice.  You'll also need to consult Sanguine Codex to decipher the original spell.

However the recipe "Restored Ritual Blade" requires Oaths to The Chalice OR Sanguine Codex, contradicting the Hermits words of needing both

Solution:
Make the two books seperate requirements for the recipe rather than substitutes for each other

Also the book "book_syncretism" which is the A Story in Shadow is nowhere mentioned by the hermit. If this is still a valid book, I'll add it back in if you want me to.

Alternatives considered:
The hermit lied to me :(