### PR TITLE
Implement a new weapon for sanguine shrikes

### DIFF
--- a/Arcana/ammo_effects.json
+++ b/Arcana/ammo_effects.json
@@ -139,5 +139,10 @@
     "id": "ARCANA_DAZZLE_SHOT",
     "type": "ammo_effect",
     "aoe": { "field_type": "fd_dazzling", "intensity_min": 3, "intensity_max": 3, "radius": 0, "chance": 100 }
+  },
+  {
+    "id": "ARCANA_SHRIKE_COLD_BULLET",
+    "type": "ammo_effect",
+    "aoe": { "field_type": "fd_fog_arcana", "intensity_min": 1, "intensity_max": 1, "size": 1, "radius": 0, "chance": 100 }
   }
 ]

--- a/Arcana/field_type.json
+++ b/Arcana/field_type.json
@@ -64,7 +64,7 @@
     ],
     "immunity_data": { "traits": [ "ARCANA_DRAGONFIRE" ] },
     "priority": 8,
-    "half_life": "1 seconds",
+    "half_life": "10 seconds",
     "phase": "gas",
     "display_items": false,
     "display_field": true,

--- a/Arcana/item_groups/item_groups_general.json
+++ b/Arcana/item_groups/item_groups_general.json
@@ -93,6 +93,7 @@
     "items": [
       [ "thunder_sigil", 5 ],
       [ "bloodscourge", 5 ],
+      [ "lichhook", 5 ],
       [ "bloodaxe", 15 ],
       [ "spear_pestilence", 10 ],
       [ "sun_sword", 10 ],
@@ -103,6 +104,7 @@
       [ "somen_clairvoyance", 5 ],
       [ "revenant_crown", 10 ],
       [ "gauntlets_necro", 15 ],
+      [ "shrike_misericorde", 1 ],
       [ "thermic_essence_cutter", 1 ]
     ]
   },
@@ -394,6 +396,23 @@
       { "item": "AID_bio_essence_surge_cell", "prob": 20 },
       { "item": "AID_bio_temporal_stimulation", "prob": 20 },
       { "item": "AID_bio_life_sign_suppression", "prob": 20 }
+    ]
+  },
+  {
+    "id": "vault_magic_item_stash",
+    "type": "item_group",
+    "items": [
+      [ "arcanemap", 10 ],
+      [ "hexenhammer", 5 ],
+      [ "offering_chalice", 5 ],
+      [ "blood_athame", 5 ],
+      [ "mana_gem", 2 ],
+      [ "mana_gem_blood", 2 ],
+      [ "mana_gem_dull", 1 ],
+      [ "totem_elecresist", 1 ],
+      [ "totem_clairvoyance", 1 ],
+      [ "totem_insight", 1 ],
+      [ "totem_lightning", 1 ]
     ]
   }
 ]

--- a/Arcana/item_groups/item_groups_sanguine.json
+++ b/Arcana/item_groups/item_groups_sanguine.json
@@ -52,7 +52,15 @@
   {
     "id": "sanguine_cult_gear",
     "type": "item_group",
-    "items": [ [ "blood_athame", 10 ], [ "bloodaxe", 3 ], [ "bloodscourge", 2 ], [ "armor_wyrm", 3 ], [ "revenant_crown", 2 ] ]
+    "items": [
+      [ "blood_athame", 35 ],
+      [ "bloodaxe", 10 ],
+      [ "lichhook", 5 ],
+      [ "bloodscourge", 20 ],
+      [ "shrike_misericorde", 5 ],
+      [ "armor_wyrm", 15 ],
+      [ "revenant_crown", 10 ]
+    ]
   },
   {
     "id": "sanguine_cult_consumables",

--- a/Arcana/item_groups/item_groups_vanilla.json
+++ b/Arcana/item_groups/item_groups_vanilla.json
@@ -128,17 +128,7 @@
       "items": [
         { "group": "magic_books", "prob": 25 },
         { "group": "autodoc_installation_magitech", "prob": 10 },
-        [ "arcanemap", 10 ],
-        [ "hexenhammer", 5 ],
-        [ "offering_chalice", 5 ],
-        [ "blood_athame", 5 ],
-        [ "mana_gem", 2 ],
-        [ "mana_gem_blood", 2 ],
-        [ "mana_gem_dull", 1 ],
-        [ "totem_elecresist", 1 ],
-        [ "totem_clairvoyance", 1 ],
-        [ "totem_insight", 1 ],
-        [ "totem_lightning", 1 ]
+        { "group": "vault_magic_item_stash", "prob": 10 }
       ]
     }
   },
@@ -157,6 +147,7 @@
         { "item": "revenant_crown", "prob": 1 },
         { "item": "gauntlets_necro", "prob": 1 },
         { "item": "thunder_sigil", "prob": 1 },
+        { "item": "shrike_misericorde", "prob": 1 },
         { "item": "brooch_iridescent", "prob": 3 }
       ]
     }

--- a/Arcana/items/ranged.json
+++ b/Arcana/items/ranged.json
@@ -113,6 +113,64 @@
     ]
   },
   {
+    "id": "shrike_misericorde_folded",
+    "looks_like": "pistol_flintlock",
+    "type": "GUN",
+    "category": "weapons",
+    "reload_noise_volume": 10,
+    "name": { "str": "shrike's misericorde (pistol)", "str_pl": "shrike's misericordes (pistol)" },
+    "description": "An ornate silver weapon combining two flintlock barrels with a thin blade.  It's folded into its more compact pistol form, allowing it to be loaded and fired.  Its shots are imbued with a deathly chill.  The damage it adds to shots can ignore mundane armor, but robots and certain otherworldly monsters will only suffer the bullet's regular damage.  Activate it to revert back to blade form, making it better suited for melee but preventing you from being able to load or fire it.",
+    "weight": "2 kg",
+    "volume": "500 ml",
+    "longest_side": "36 cm",
+    "price": "1000 USD",
+    "price_postapoc": "50 USD",
+    "to_hit": -1,
+    "bashing": 12,
+    "cutting": 8,
+    "material": [ "iron", "silver" ],
+    "symbol": "(",
+    "color": "light_gray",
+    "ammo": [ "flintlock" ],
+    "skill": "pistol",
+    "range": 2,
+    "ranged_damage": { "damage_type": "cold", "amount": 10 },
+    "dispersion": 700,
+    "durability": 6,
+    "blackpowder_tolerance": 96,
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "flintlock": 2 } } ],
+    "reload": 700,
+    "modes": [ [ "DEFAULT", "single", 1 ], [ "DOUBLE", "double", 2 ] ],
+    "techniques": [ "WBLOCK_1" ],
+    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 9 ] ],
+    "flags": [ "STAB", "NEVER_JAMS", "DURABLE_MELEE", "NO_SALVAGE", "PRIMITIVE_RANGED_WEAPON", "RELOAD_ONE" ],
+    "ammo_effects": [ "ARCANA_SHRIKE_COLD_BULLET" ],
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WIELD",
+          "condition": "ALWAYS",
+          "hit_you_effect": [
+            {
+              "id": "arcana_react_shrike_misericorde_chill",
+              "once_in": 5,
+              "message": "An unearthly chill radiates from your weapon.",
+              "npc_message": "An unearthly chill radiates from %1$s's weapon."
+            }
+          ]
+        }
+      ]
+    },
+    "use_action": {
+      "menu_text": "Unfold into blade mode",
+      "type": "transform",
+      "target": "shrike_misericorde",
+      "msg": "The weapon splinters and unfurls, reforming into its blade form.",
+      "need_wielding": true,
+      "ammo_scale": 0
+    }
+  },
+  {
     "id": "ethereal_crossbow",
     "type": "GUN",
     "category": "weapons",

--- a/Arcana/items/tools.json
+++ b/Arcana/items/tools.json
@@ -1190,6 +1190,54 @@
     "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "LIGHT_8", "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {
+    "id": "shrike_misericorde",
+    "looks_like": "rapier",
+    "type": "TOOL",
+    "category": "weapons",
+    "name": { "str": "shrike's misericorde" },
+    "description": "An ornate silver weapon featuring a thin blade and two flintlock barrels built into the guard.  Its strikes inflict victims with a deathly chill.  Activating it will transform it into a more compact form, allowing its user to load and fire it.  Its pistol form will impart a freezing effect on shots fired from it, including otherworldly damage that can bypass mundane armor, though robots and certain supernatural monsters will only suffer the bullet's normal damage.",
+    "weight": "2 kg",
+    "volume": "1500 ml",
+    "longest_side": "90 cm",
+    "price": "1000 USD",
+    "price_postapoc": "50 USD",
+    "to_hit": 2,
+    "bashing": 12,
+    "cutting": 24,
+    "material": [ "iron", "silver" ],
+    "symbol": "/",
+    "color": "light_gray",
+    "ammo": [ "flintlock" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "flintlock": 2 } } ],
+    "techniques": [ "RAPID", "WBLOCK_2", "PRECISE" ],
+    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 9 ] ],
+    "flags": [ "STAB", "DURABLE_MELEE", "SHEATH_SWORD", "NO_SALVAGE", "NO_RELOAD", "NO_UNLOAD" ],
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WIELD",
+          "condition": "ALWAYS",
+          "hit_you_effect": [
+            {
+              "id": "arcana_react_shrike_misericorde_chill",
+              "once_in": 5,
+              "message": "An unearthly chill radiates from your weapon.",
+              "npc_message": "An unearthly chill radiates from %1$s's weapon."
+            }
+          ]
+        }
+      ]
+    },
+    "use_action": {
+      "menu_text": "Fold into pistol mode",
+      "type": "transform",
+      "target": "shrike_misericorde_folded",
+      "msg": "The weapon splinters and compacts, reforming into its pistol form.",
+      "need_wielding": true,
+      "ammo_scale": 0
+    }
+  },
+  {
     "id": "lichhook",
     "copy-from": "khopesh",
     "type": "TOOL",

--- a/Arcana/martialarts.json
+++ b/Arcana/martialarts.json
@@ -42,7 +42,7 @@
     "copy-from": "style_fencing",
     "type": "martial_art",
     "name": { "str": "Fencing" },
-    "extend": { "weapons": [ "sun_sword", "sun_sword_on", "staff_druidic", "verge_meteoric" ] }
+    "extend": { "weapons": [ "sun_sword", "sun_sword_on", "shrike_misericorde", "staff_druidic", "verge_meteoric" ] }
   },
   {
     "id": "style_swordsmanship",
@@ -387,6 +387,8 @@
       "crash_axe",
       "hatchet",
       "lichhook",
+      "shrike_misericorde",
+      "shrike_misericorde_folded",
       "sword_bayonet",
       "sword_bayonet_mod",
       "makeshift_machete",

--- a/Arcana/npcs/NC_FILES.json
+++ b/Arcana/npcs/NC_FILES.json
@@ -938,10 +938,11 @@
     "id": "NC_BLOOD_MAGE_SHRIKE_weapon",
     "ammo": 100,
     "items": [
-      [ "pistol_flintlock", 50 ],
+      [ "pistol_flintlock", 40 ],
       [ "carbine_flintlock", 25 ],
       [ "rifle_flintlock", 15 ],
-      [ "carbine_flintlock_double", 10 ]
+      [ "carbine_flintlock_double", 10 ],
+      [ "shrike_misericorde_folded", 10 ]
     ]
   },
   {

--- a/Arcana/recipes/recipe_deconstruction.json
+++ b/Arcana/recipes/recipe_deconstruction.json
@@ -799,6 +799,26 @@
     "components": [ [ [ "scrap", 12 ] ], [ [ "essence_dull", 50 ] ] ]
   },
   {
+    "result": "shrike_misericorde",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 6,
+    "time": "60 m",
+    "activity_level": "LIGHT_EXERCISE",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "scrap", 10 ] ], [ [ "silver_small", 500 ] ], [ [ "essence_dull", 120 ] ] ]
+  },
+  {
+    "result": "shrike_misericorde_folded",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 6,
+    "time": "60 m",
+    "activity_level": "LIGHT_EXERCISE",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "scrap", 10 ] ], [ [ "silver_small", 500 ] ], [ [ "essence_dull", 120 ] ] ]
+  },
+  {
     "result": "lichhook",
     "type": "uncraft",
     "skill_used": "magic",

--- a/Arcana/recipes/recipe_weapon.json
+++ b/Arcana/recipes/recipe_weapon.json
@@ -391,6 +391,32 @@
     "flags": [ "SECRET" ]
   },
   {
+    "result": "shrike_misericorde",
+    "type": "recipe",
+    "category": "CC_ARCANA",
+    "subcategory": "CSC_ARCANA_WEAPON",
+    "skill_used": "magic",
+    "difficulty": 7,
+    "skills_required": [ [ "fabrication", 7 ], [ "mechanics", 4 ], [ "pistol", 3 ] ],
+    "time": "120 m",
+    "activity_level": "LIGHT_EXERCISE",
+    "book_learn": [ [ "book_bloodmagic", 7 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "proficiencies": [ { "proficiency": "prof_metalworking", "required": false, "time_multiplier": 2 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "CHISEL", "level": 3 } ],
+    "tools": [ [ [ "swage", -1 ] ], [ [ "book_bloodmagic", -1 ] ] ],
+    "components": [
+      [ [ "silver_small", 500 ] ],
+      [ [ "2x4", 1 ], [ "stick", 1 ] ],
+      [ [ "fur", 1 ], [ "leather", 1 ] ],
+      [ [ "pipe", 2 ] ],
+      [ [ "sharp_rock", 2 ] ],
+      [ [ "shadow_gem", 1 ], [ "vortex_shard", 1 ] ],
+      [ [ "essence_blood", 10 ] ]
+    ],
+    "flags": [ "SECRET" ]
+  },
+  {
     "result": "lichhook",
     "type": "recipe",
     "category": "CC_ARCANA",
@@ -399,6 +425,7 @@
     "difficulty": 6,
     "skills_required": [ "fabrication", 4 ],
     "time": "80 m",
+    "activity_level": "LIGHT_EXERCISE",
     "book_learn": [ [ "book_bloodmagic", 6 ] ],
     "using": [ [ "arcana_holy_symbol_any", 1 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "ANVIL", "level": 1 } ],

--- a/Arcana/spells/spells_react.json
+++ b/Arcana/spells/spells_react.json
@@ -274,5 +274,21 @@
     "max_damage": 1,
     "min_aoe": 3,
     "max_aoe": 3
+  },
+  {
+    "id": "arcana_react_shrike_misericorde_chill",
+    "type": "SPELL",
+    "name": { "str": "React: Cold Mercy" },
+    "description": "Cold effect on melee.",
+    "message": "An unearthly chill radiates from your weapon.",
+    "flags": [ "SILENT", "RANDOM_DURATION" ],
+    "valid_targets": [ "hostile" ],
+    "effect_str": "arcana_lingering_chill",
+    "min_range": 1,
+    "max_range": 1,
+    "effect": "attack",
+    "shape": "blast",
+    "min_duration": 500,
+    "max_duration": 1000
   }
 ]

--- a/Arcana_BN/ammo_effects.json
+++ b/Arcana_BN/ammo_effects.json
@@ -139,5 +139,10 @@
     "id": "ARCANA_DAZZLE_SHOT",
     "type": "ammo_effect",
     "aoe": { "field_type": "fd_dazzling", "intensity_min": 3, "intensity_max": 3, "radius": 0, "chance": 100 }
+  },
+  {
+    "id": "ARCANA_SHRIKE_COLD_BULLET",
+    "type": "ammo_effect",
+    "aoe": { "field_type": "fd_fog_arcana", "intensity_min": 1, "intensity_max": 1, "size": 1, "radius": 0, "chance": 100 }
   }
 ]

--- a/Arcana_BN/field_type.json
+++ b/Arcana_BN/field_type.json
@@ -64,7 +64,7 @@
     ],
     "immunity_data": { "traits": [ "ARCANA_DRAGONFIRE" ] },
     "priority": 8,
-    "half_life": "1 seconds",
+    "half_life": "10 seconds",
     "phase": "gas",
     "display_items": false,
     "display_field": true,

--- a/Arcana_BN/item_groups/item_groups_general.json
+++ b/Arcana_BN/item_groups/item_groups_general.json
@@ -93,6 +93,7 @@
     "items": [
       [ "thunder_sigil", 5 ],
       [ "bloodscourge", 5 ],
+      [ "lichhook", 5 ],
       [ "bloodaxe", 15 ],
       [ "spear_pestilence", 10 ],
       [ "sun_sword", 10 ],
@@ -103,6 +104,7 @@
       [ "somen_clairvoyance", 5 ],
       [ "revenant_crown", 10 ],
       [ "gauntlets_necro", 15 ],
+      [ "shrike_misericorde", 1 ],
       [ "thermic_essence_cutter", 1 ]
     ]
   },
@@ -386,6 +388,23 @@
       { "item": "AID_bio_essence_surge_cell", "prob": 20 },
       { "item": "AID_bio_temporal_stimulation", "prob": 20 },
       { "item": "AID_bio_life_sign_suppression", "prob": 20 }
+    ]
+  },
+  {
+    "id": "vault_magic_item_stash",
+    "type": "item_group",
+    "items": [
+      [ "arcanemap", 10 ],
+      [ "hexenhammer", 5 ],
+      [ "offering_chalice", 5 ],
+      [ "blood_athame", 5 ],
+      [ "mana_gem", 2 ],
+      [ "mana_gem_blood", 2 ],
+      [ "mana_gem_dull", 1 ],
+      [ "totem_elecresist", 1 ],
+      [ "totem_clairvoyance", 1 ],
+      [ "totem_insight", 1 ],
+      [ "totem_lightning", 1 ]
     ]
   }
 ]

--- a/Arcana_BN/item_groups/item_groups_sanguine.json
+++ b/Arcana_BN/item_groups/item_groups_sanguine.json
@@ -52,7 +52,15 @@
   {
     "id": "sanguine_cult_gear",
     "type": "item_group",
-    "items": [ [ "blood_athame", 10 ], [ "bloodaxe", 3 ], [ "bloodscourge", 2 ], [ "armor_wyrm", 3 ], [ "revenant_crown", 2 ] ]
+    "items": [
+      [ "blood_athame", 35 ],
+      [ "bloodaxe", 10 ],
+      [ "lichhook", 5 ],
+      [ "bloodscourge", 20 ],
+      [ "shrike_misericorde", 5 ],
+      [ "armor_wyrm", 15 ],
+      [ "revenant_crown", 10 ]
+    ]
   },
   {
     "id": "sanguine_cult_consumables",

--- a/Arcana_BN/item_groups/item_groups_vanilla.json
+++ b/Arcana_BN/item_groups/item_groups_vanilla.json
@@ -103,17 +103,7 @@
     "items": [
       { "group": "magic_books", "prob": 25 },
       { "group": "autodoc_installation_magitech", "prob": 10 },
-      [ "arcanemap", 10 ],
-      [ "hexenhammer", 5 ],
-      [ "offering_chalice", 5 ],
-      [ "blood_athame", 5 ],
-      [ "mana_gem", 2 ],
-      [ "mana_gem_blood", 2 ],
-      [ "mana_gem_dull", 1 ],
-      [ "totem_elecresist", 1 ],
-      [ "totem_clairvoyance", 1 ],
-      [ "totem_insight", 1 ],
-      [ "totem_lightning", 1 ]
+      { "group": "vault_magic_item_stash", "prob": 10 }
     ]
   },
   {
@@ -129,6 +119,7 @@
       { "item": "revenant_crown", "prob": 1 },
       { "item": "gauntlets_necro", "prob": 1 },
       { "item": "thunder_sigil", "prob": 1 },
+      { "item": "shrike_misericorde", "prob": 1 },
       { "item": "brooch_iridescent", "prob": 3 }
     ]
   },

--- a/Arcana_BN/items/ranged.json
+++ b/Arcana_BN/items/ranged.json
@@ -102,6 +102,61 @@
     ]
   },
   {
+    "id": "shrike_misericorde_folded",
+    "looks_like": "pistol_flintlock",
+    "type": "GUN",
+    "category": "weapons",
+    "reload_noise_volume": 10,
+    "name": { "str": "shrike's misericorde (pistol)", "str_pl": "shrike's misericordes (pistol)" },
+    "description": "An ornate silver weapon combining two flintlock barrels with a thin blade.  It's folded into its more compact pistol form, allowing it to be loaded and fired.  Its shots are imbued with a deathly chill.  The damage it adds to shots can ignore mundane armor, but robots and certain otherworldly monsters will only suffer the bullet's regular damage.  Activate it to revert back to blade form, making it better suited for melee but preventing you from being able to load or fire it.",
+    "weight": "2 kg",
+    "volume": "500 ml",
+    "price": "1000 USD",
+    "price_postapoc": "50 USD",
+    "to_hit": -1,
+    "bashing": 12,
+    "cutting": 8,
+    "material": [ "iron", "silver" ],
+    "symbol": "(",
+    "color": "light_gray",
+    "ammo": [ "flintlock" ],
+    "skill": "pistol",
+    "range": 2,
+    "ranged_damage": { "damage_type": "cold", "amount": 10 },
+    "dispersion": 700,
+    "durability": 6,
+    "blackpowder_tolerance": 96,
+    "clip_size": 2,
+    "reload": 700,
+    "modes": [ [ "DEFAULT", "single", 1 ], [ "DOUBLE", "double", 2 ] ],
+    "techniques": [ "WBLOCK_1" ],
+    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 9 ] ],
+    "flags": [ "STAB", "NEVER_JAMS", "DURABLE_MELEE", "NO_SALVAGE", "PRIMITIVE_RANGED_WEAPON", "RELOAD_ONE" ],
+    "ammo_effects": [ "ARCANA_SHRIKE_COLD_BULLET" ],
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WIELD",
+          "condition": "ALWAYS",
+          "hit_you_effect": [
+            {
+              "id": "arcana_react_shrike_misericorde_chill",
+              "once_in": 5,
+              "message": "An unearthly chill radiates from your weapon.",
+              "npc_message": "An unearthly chill radiates from %1$s's weapon."
+            }
+          ]
+        }
+      ]
+    },
+    "use_action": {
+      "menu_text": "Unfold into blade mode",
+      "type": "transform",
+      "target": "shrike_misericorde",
+      "msg": "The weapon splinters and unfurls, reforming into its blade form."
+    }
+  },
+  {
     "id": "ethereal_crossbow",
     "type": "GUN",
     "category": "weapons",

--- a/Arcana_BN/items/ranged.json
+++ b/Arcana_BN/items/ranged.json
@@ -153,7 +153,8 @@
       "menu_text": "Unfold into blade mode",
       "type": "transform",
       "target": "shrike_misericorde",
-      "msg": "The weapon splinters and unfurls, reforming into its blade form."
+      "msg": "The weapon splinters and unfurls, reforming into its blade form.",
+      "need_wielding": true
     }
   },
   {

--- a/Arcana_BN/items/tools.json
+++ b/Arcana_BN/items/tools.json
@@ -1209,7 +1209,8 @@
       "menu_text": "Fold into pistol mode",
       "type": "transform",
       "target": "shrike_misericorde_folded",
-      "msg": "The weapon splinters and compacts, reforming into its pistol form."
+      "msg": "The weapon splinters and compacts, reforming into its pistol form.",
+      "need_wielding": true
     }
   },
   {

--- a/Arcana_BN/items/tools.json
+++ b/Arcana_BN/items/tools.json
@@ -1168,6 +1168,51 @@
     "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "LIGHT_8", "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {
+    "id": "shrike_misericorde",
+    "looks_like": "rapier",
+    "type": "TOOL",
+    "category": "weapons",
+    "name": { "str": "shrike's misericorde" },
+    "description": "An ornate silver weapon featuring a thin blade and two flintlock barrels built into the guard.  Its strikes inflict victims with a deathly chill.  Activating it will transform it into a more compact form, allowing its user to load and fire it.  Its pistol form will impart a freezing effect on shots fired from it, including otherworldly damage that can bypass mundane armor, though robots and certain supernatural monsters will only suffer the bullet's normal damage.",
+    "weight": "2 kg",
+    "volume": "1500 ml",
+    "price": "1000 USD",
+    "price_postapoc": "50 USD",
+    "to_hit": 2,
+    "bashing": 12,
+    "cutting": 24,
+    "material": [ "iron", "silver" ],
+    "symbol": "/",
+    "color": "light_gray",
+    "ammo": [ "flintlock" ],
+    "max_charges": 2,
+    "techniques": [ "RAPID", "WBLOCK_2", "PRECISE" ],
+    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 9 ] ],
+    "flags": [ "STAB", "DURABLE_MELEE", "SHEATH_SWORD", "NO_SALVAGE", "NO_RELOAD", "NO_UNLOAD" ],
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WIELD",
+          "condition": "ALWAYS",
+          "hit_you_effect": [
+            {
+              "id": "arcana_react_shrike_misericorde_chill",
+              "once_in": 5,
+              "message": "An unearthly chill radiates from your weapon.",
+              "npc_message": "An unearthly chill radiates from %1$s's weapon."
+            }
+          ]
+        }
+      ]
+    },
+    "use_action": {
+      "menu_text": "Fold into pistol mode",
+      "type": "transform",
+      "target": "shrike_misericorde_folded",
+      "msg": "The weapon splinters and compacts, reforming into its pistol form."
+    }
+  },
+  {
     "id": "lichhook",
     "copy-from": "khopesh",
     "type": "TOOL",

--- a/Arcana_BN/martialarts.json
+++ b/Arcana_BN/martialarts.json
@@ -42,7 +42,7 @@
     "copy-from": "style_fencing",
     "type": "martial_art",
     "name": { "str": "Fencing" },
-    "extend": { "weapons": [ "sun_sword", "sun_sword_on", "staff_druidic", "verge_meteoric" ] }
+    "extend": { "weapons": [ "sun_sword", "sun_sword_on", "shrike_misericorde", "staff_druidic", "verge_meteoric" ] }
   },
   {
     "id": "style_swordsmanship",
@@ -379,6 +379,8 @@
       "crash_axe",
       "hatchet",
       "lichhook",
+      "shrike_misericorde",
+      "shrike_misericorde_folded",
       "sword_bayonet",
       "sword_bayonet_mod",
       "makeshift_machete",

--- a/Arcana_BN/npcs/NC_FILES.json
+++ b/Arcana_BN/npcs/NC_FILES.json
@@ -527,7 +527,11 @@
     "name": { "str": "Ambusher" },
     "common": false,
     "job_description": "I kill people.  Duh.",
-    "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "Arcanist_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "traits": [
+      { "group": "BG_survival_story_EVACUEE" },
+      { "group": "Arcanist_starting_traits" },
+      { "group": "Appearance_demographics" }
+    ],
     "bonus_str": { "rng": [ -2, 3 ] },
     "bonus_dex": { "rng": [ -1, 1 ] },
     "bonus_int": { "rng": [ -1, 1 ] },
@@ -1105,10 +1109,7 @@
     "type": "item_group",
     "id": "NC_BANDIT_PURIFIER_AMBUSHER_misc",
     "subtype": "collection",
-    "entries": [
-      { "item": "ref_lighter", "charges": 50 },
-      { "group": "cleansing_flame_gear_consumables" }
-    ]
+    "entries": [ { "item": "ref_lighter", "charges": 50 }, { "group": "cleansing_flame_gear_consumables" } ]
   },
   {
     "id": "NC_BANDIT_PURIFIER_AMBUSHER_worn",
@@ -1133,7 +1134,9 @@
     "type": "item_group",
     "id": "NC_BANDIT_PURIFIER_AMBUSHER_weapon",
     "subtype": "collection",
-    "entries": [ { "item": "winchester_1897", "ammo-item": "reloaded_shot_00_arcana", "charges": 6, "contents-item": "shoulder_strap" } ]
+    "entries": [
+      { "item": "winchester_1897", "ammo-item": "reloaded_shot_00_arcana", "charges": 6, "contents-item": "shoulder_strap" }
+    ]
   },
   {
     "id": "NC_ARSONIST_random",

--- a/Arcana_BN/npcs/NC_FILES.json
+++ b/Arcana_BN/npcs/NC_FILES.json
@@ -931,10 +931,11 @@
     "id": "NC_BLOOD_MAGE_SHRIKE_weapon",
     "ammo": 100,
     "items": [
-      [ "pistol_flintlock", 50 ],
+      [ "pistol_flintlock", 40 ],
       [ "carbine_flintlock", 25 ],
       [ "rifle_flintlock", 15 ],
-      [ "carbine_flintlock_double", 10 ]
+      [ "carbine_flintlock_double", 10 ],
+      [ "shrike_misericorde_folded", 10 ]
     ]
   },
   {

--- a/Arcana_BN/recipes/recipe_deconstruction.json
+++ b/Arcana_BN/recipes/recipe_deconstruction.json
@@ -660,6 +660,24 @@
     "components": [ [ [ "scrap", 12 ] ], [ [ "essence_dull", 50 ] ] ]
   },
   {
+    "result": "shrike_misericorde",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 6,
+    "time": "60 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "scrap", 10 ] ], [ [ "silver_small", 500 ] ], [ [ "essence_dull", 120 ] ] ]
+  },
+  {
+    "result": "shrike_misericorde_folded",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 6,
+    "time": "60 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "scrap", 10 ] ], [ [ "silver_small", 500 ] ], [ [ "essence_dull", 120 ] ] ]
+  },
+  {
     "result": "lichhook",
     "type": "uncraft",
     "skill_used": "magic",

--- a/Arcana_BN/recipes/recipe_weapon.json
+++ b/Arcana_BN/recipes/recipe_weapon.json
@@ -351,6 +351,30 @@
     "flags": [ "SECRET" ]
   },
   {
+    "result": "shrike_misericorde",
+    "type": "recipe",
+    "category": "CC_ARCANA",
+    "subcategory": "CSC_ARCANA_WEAPON",
+    "skill_used": "magic",
+    "difficulty": 7,
+    "skills_required": [ [ "fabrication", 7 ], [ "mechanics", 4 ], [ "pistol", 3 ] ],
+    "time": "120 m",
+    "book_learn": [ [ "book_bloodmagic", 7 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "CHISEL", "level": 3 } ],
+    "tools": [ [ [ "swage", -1 ] ], [ [ "book_bloodmagic", -1 ] ] ],
+    "components": [
+      [ [ "silver_small", 500 ] ],
+      [ [ "2x4", 1 ], [ "stick", 1 ] ],
+      [ [ "fur", 1 ], [ "leather", 1 ] ],
+      [ [ "pipe", 2 ] ],
+      [ [ "sharp_rock", 2 ] ],
+      [ [ "shadow_gem", 1 ], [ "vortex_shard", 1 ] ],
+      [ [ "essence_blood", 10 ] ]
+    ],
+    "flags": [ "SECRET" ]
+  },
+  {
     "result": "lichhook",
     "type": "recipe",
     "category": "CC_ARCANA",

--- a/Arcana_BN/spells/spells_react.json
+++ b/Arcana_BN/spells/spells_react.json
@@ -258,5 +258,21 @@
     "effect": "target_attack",
     "min_duration": 100,
     "max_duration": 500
+  },
+  {
+    "id": "arcana_react_shrike_misericorde_chill",
+    "type": "SPELL",
+    "name": { "str": "React: Cold Mercy" },
+    "sprite": "fd_fog",
+    "description": "Cold effect on melee.",
+    "message": "An unearthly chill radiates from your weapon.",
+    "flags": [ "SILENT", "RANDOM_DURATION" ],
+    "valid_targets": [ "hostile" ],
+    "effect_str": "arcana_lingering_chill",
+    "min_range": 1,
+    "max_range": 1,
+    "effect": "target_attack",
+    "min_duration": 500,
+    "max_duration": 1000
   }
 ]


### PR DESCRIPTION
- [x] Added a new item. Two new items technically, a transforming weapon learned from Sanguine Codex. Favors cold-type damage and flavored as being a sanguine shrike weapon, with a melee form and ranged form.
- [x] Added recipe and uncraft for the new item.
- [x] Added ammo effect used by the gun form.
- [x] Misc: tweaked the half-life of chill fields to last long enough for monsters shot with the weapon to actually suffer from it.
- [x] Need to also add martial arts injections of the weapon.
- [x] Added to relevant itemgroups and to shrike NPCs.
- [x] Misc: Updated magic item groups to also include lichhook where relevant.
- [x] Implement DDA version of above changes.
- [x] Further testing.