### PR TITLE
Fix field immunity in DDA version

### DIFF
--- a/Arcana/field_type.json
+++ b/Arcana/field_type.json
@@ -62,7 +62,7 @@
         "convection_temperature_mod": -150
       }
     ],
-    "immunity_data": { "traits": [ "ARCANA_DRAGONFIRE" ] },
+    "immunity_data": { "flags": [ "ARCANE_FOG_IMMUNE" ] },
     "priority": 8,
     "half_life": "10 seconds",
     "phase": "gas",

--- a/Arcana/mutations/mutations_dragonblood.json
+++ b/Arcana/mutations/mutations_dragonblood.json
@@ -298,7 +298,8 @@
     "cost": 500,
     "kcal": true,
     "ranged_mutation": { "type": "mut_dragonfire", "message": "You loose a tongue of flame from your mouth." },
-    "vitamin_rates": [ [ "blood", -5 ], [ "redcells", -5 ] ]
+    "vitamin_rates": [ [ "blood", -5 ], [ "redcells", -5 ] ],
+    "flags": [ "ARCANE_FOG_IMMUNE" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
Due to https://github.com/CleverRaven/Cataclysm-DDA/commit/4840ee2e553ca74e14f3bbd624750cc51766ec8f 
(Limbify/flagify field immunity)

Of course you can modify the flag name to the one you like.

I evaluated `BRRR_FOG_IMMUNE`, `OH_SHIT_ITS_COLD_IMMUNE`, `COLD_FOG_IMMUNE`, `DEADLY_FOG_IMMUNE`.