### PR TITLE
Satchel of Eternity can't use pocket move cost 0 or game throws error…

### DIFF
--- a/Arcana/items/armor.json
+++ b/Arcana/items/armor.json
@@ -324,7 +324,7 @@
       {
         "max_contains_volume": "5 L",
         "max_contains_weight": "25 kg",
-        "moves": 0,
+        "moves": 1,
         "rigid": true,
         "holster": true,
         "flag_restriction": [ "MAGIC_FOCUS" ]
@@ -332,7 +332,7 @@
       {
         "max_contains_volume": "5 L",
         "max_contains_weight": "25 kg",
-        "moves": 0,
+        "moves": 1,
         "rigid": true,
         "holster": true,
         "flag_restriction": [ "MAGIC_FOCUS" ]
@@ -340,7 +340,7 @@
       {
         "max_contains_volume": "5 L",
         "max_contains_weight": "25 kg",
-        "moves": 0,
+        "moves": 1,
         "rigid": true,
         "holster": true,
         "flag_restriction": [ "MAGIC_FOCUS" ]
@@ -348,7 +348,7 @@
       {
         "max_contains_volume": "5 L",
         "max_contains_weight": "25 kg",
-        "moves": 0,
+        "moves": 1,
         "rigid": true,
         "holster": true,
         "flag_restriction": [ "MAGIC_FOCUS" ]


### PR DESCRIPTION
When trying to wield an item stored in a pocket with 0 move cost causes this error:
`ERROR : src/item_location.cpp:675 [virtual int item_location::impl::item_in_container::obtain_cost(const Character&, int) const] ERROR: <color_c_light_green>||</color> satchel of eternity > 30 items does not contain symbol of judgment`
I don't know whether the same thing happens in the BN version.