### PR TITLE
Monster drop fixes

### DIFF
--- a/Arcana/monsters/monster_drops.json
+++ b/Arcana/monsters/monster_drops.json
@@ -781,7 +781,11 @@
     "type": "item_group",
     "id": "mon_gelatin_death_drops",
     "subtype": "collection",
-    "entries": [ { "item": "blob_gem", "prob": 50 }, { "item": "essence", "prob": 50, "count": [ 1, 3 ] } ]
+    "entries": [
+      { "item": "slime_sample", "count-min": 1, "count-max": 3 },
+      { "item": "blob_gem", "prob": 50 },
+      { "item": "essence", "prob": 50, "count": [ 1, 3 ] }
+    ]
   },
   {
     "type": "item_group",

--- a/Arcana/monsters/monster_drops.json
+++ b/Arcana/monsters/monster_drops.json
@@ -498,9 +498,14 @@
   },
   {
     "type": "item_group",
-    "id": "mon_blob_small_death_drops",
+    "id": "mon_blob_small_deathdrops",
+    "copy-from": "mon_blob_small_deathdrops",
     "subtype": "collection",
-    "entries": [ { "item": "blob_gem", "prob": 5 }, { "item": "essence", "prob": 5, "count": [ 1, 3 ] } ]
+    "extend": {
+      "entries": [
+        { "item": "blob_gem", "prob": 5 }, { "item": "essence", "prob": 5, "count": [ 1, 3 ] }
+      ]
+    }
   },
   {
     "type": "item_group",

--- a/Arcana/monsters/monster_drops.json
+++ b/Arcana/monsters/monster_drops.json
@@ -502,9 +502,7 @@
     "copy-from": "mon_blob_small_deathdrops",
     "subtype": "collection",
     "extend": {
-      "entries": [
-        { "item": "blob_gem", "prob": 5 }, { "item": "essence", "prob": 5, "count": [ 1, 3 ] }
-      ]
+      "entries": [ { "item": "blob_gem", "prob": 5 }, { "item": "essence", "prob": 5, "count": [ 1, 3 ] } ]
     }
   },
   {

--- a/Arcana/monsters/monster_overrides.json
+++ b/Arcana/monsters/monster_overrides.json
@@ -291,7 +291,7 @@
     "id": "mon_blob_small",
     "copy-from": "mon_blob_small",
     "type": "MONSTER",
-    "death_drops": "mon_blob_small_death_drops"
+    "death_drops": "mon_blob_small_deathdrops"
   },
   {
     "id": "mon_one_eye",


### PR DESCRIPTION
Noticed while playing that `small slimes` weren't dropping `slime_scrap` so went ahead and fixed that.
`Amoebic mold` also wasn't dropping samples so included a fix for that (possibly other monsters with that problem).
Did in-game testing to make sure it worked, feel free to change this however you like.