### PR TITLE
Honed claws buff fix

### DIFF
--- a/Arcana/martialarts.json
+++ b/Arcana/martialarts.json
@@ -343,11 +343,24 @@
       },
       {
         "id": "buff_shrike_onattack2",
-        "name": "Honed Claws",
+        "name": "Honed Claws(Unarmed)",
         "description": "Empty-handed does not always mean unarmed.\n\nCut/stab armor penetration increased by 50% of dexterity.\nLasts 2 turns.  Stacks 3 times.",
         "//": "All unarmed weapons are permitted, but using the tiger claws, bionic claws, or demon claw is recommended since the other buffs and techniques are off-limits to other unarmed weapons.",
         "unarmed_allowed": true,
+		"unarmed_weapons_allowed": true,
         "skill_requirements": [ { "name": "unarmed", "level": 3 }, { "name": "magic", "level": 4 } ],
+        "buff_duration": 2,
+        "max_stacks": 3,
+        "flat_bonuses": [ { "stat": "arpen", "type": "cut", "scaling-stat": "dex", "scale": 0.5 } ]
+      },
+	  {
+        "id": "buff_shrike_onattack3",
+        "name": "Honed Claws(Claws)",
+        "description": "Empty-handed does not always mean unarmed.\n\nCut/stab armor penetration increased by 50% of dexterity.\nLasts 2 turns.  Stacks 3 times.",
+        "//": "All unarmed weapons are permitted, but using the tiger claws, bionic claws, or demon claw is recommended since the other buffs and techniques are off-limits to other unarmed weapons.",
+		"melee_allowed": true,
+        "weapon_categories_allowed" : [ "CLAWS" ],
+        "skill_requirements": [ { "name": "melee", "level": 3 }, { "name": "magic", "level": 4 } ],
         "buff_duration": 2,
         "max_stacks": 3,
         "flat_bonuses": [ { "stat": "arpen", "type": "cut", "scaling-stat": "dex", "scale": 0.5 } ]

--- a/Arcana/martialarts.json
+++ b/Arcana/martialarts.json
@@ -347,19 +347,19 @@
         "description": "Empty-handed does not always mean unarmed.\n\nCut/stab armor penetration increased by 50% of dexterity.\nLasts 2 turns.  Stacks 3 times.",
         "//": "All unarmed weapons are permitted, but using the tiger claws, bionic claws, or demon claw is recommended since the other buffs and techniques are off-limits to other unarmed weapons.",
         "unarmed_allowed": true,
-		"unarmed_weapons_allowed": true,
+        "unarmed_weapons_allowed": true,
         "skill_requirements": [ { "name": "unarmed", "level": 3 }, { "name": "magic", "level": 4 } ],
         "buff_duration": 2,
         "max_stacks": 3,
         "flat_bonuses": [ { "stat": "arpen", "type": "cut", "scaling-stat": "dex", "scale": 0.5 } ]
       },
-	  {
+      {
         "id": "buff_shrike_onattack3",
         "name": "Honed Claws(Claws)",
         "description": "Empty-handed does not always mean unarmed.\n\nCut/stab armor penetration increased by 50% of dexterity.\nLasts 2 turns.  Stacks 3 times.",
         "//": "All unarmed weapons are permitted, but using the tiger claws, bionic claws, or demon claw is recommended since the other buffs and techniques are off-limits to other unarmed weapons.",
-		"melee_allowed": true,
-        "weapon_categories_allowed" : [ "CLAWS" ],
+        "melee_allowed": true,
+        "weapon_categories_allowed": [ "CLAWS" ],
         "skill_requirements": [ { "name": "melee", "level": 3 }, { "name": "magic", "level": 4 } ],
         "buff_duration": 2,
         "max_stacks": 3,

--- a/Arcana/martialarts.json
+++ b/Arcana/martialarts.json
@@ -343,7 +343,7 @@
       },
       {
         "id": "buff_shrike_onattack2",
-        "name": "Honed Claws(Unarmed)",
+        "name": "Honed Claws (Unarmed)",
         "description": "Empty-handed does not always mean unarmed.\n\nCut/stab armor penetration increased by 50% of dexterity.\nLasts 2 turns.  Stacks 3 times.",
         "//": "All unarmed weapons are permitted, but using the tiger claws, bionic claws, or demon claw is recommended since the other buffs and techniques are off-limits to other unarmed weapons.",
         "unarmed_allowed": true,
@@ -355,7 +355,7 @@
       },
       {
         "id": "buff_shrike_onattack3",
-        "name": "Honed Claws(Claws)",
+        "name": "Honed Claws (Claws)",
         "description": "Empty-handed does not always mean unarmed.\n\nCut/stab armor penetration increased by 50% of dexterity.\nLasts 2 turns.  Stacks 3 times.",
         "//": "All unarmed weapons are permitted, but using the tiger claws, bionic claws, or demon claw is recommended since the other buffs and techniques are off-limits to other unarmed weapons.",
         "melee_allowed": true,


### PR DESCRIPTION
In experimental unarmed weapons have been significantly reworked. Now it only include "worn" weapons like knuckles, plus some normal armor also provide unarmed damage bonus. Claws, on the other hand, does not considered to be unarmed weapon any more. I added second version of this buff that would work with claws specifically and also add ability to used unarmed variant with unarmed weapons like mentioned in json note.

While not directly relevant to this pr, i would like to hear feedback about specifying compiteble weapons based on categories rather then specific weapons\damage types. So for example Via Gladium et Malleo would require "MEDIEVAL_SWORDS" category rather then cut damage of 20 or more. That would increase compatibility with other mods and reduce need to manually update weapon list each time new relevant weapon is added