### PR TITLE
BN version of flesh raptor drop additions

### DIFF
--- a/Arcana_BN/monsters/monster_drops.json
+++ b/Arcana_BN/monsters/monster_drops.json
@@ -80,6 +80,74 @@
   },
   {
     "type": "item_group",
+    "id": "mon_zombie_pupa_decoy_shady_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "group": "default_zombie_death_drops" },
+      { "item": "shadow_gem", "prob": 15 },
+      { "item": "essence_blood", "count": [ 2, 4 ], "prob": 30 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_zombie_pupa_shady_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "group": "default_zombie_death_drops" },
+      { "item": "shadow_gem", "prob": 15 },
+      { "item": "essence_blood", "count": [ 2, 4 ], "prob": 30 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_spawn_raptor_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "item": "bone_twisted", "prob": 5 },
+      { "item": "essence_blood", "count": [ 2, 4 ], "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_spawn_raptor_shady_death_drops",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "shadow_gem", "prob": 50 },
+          { "item": "bone_twisted", "prob": 50 }
+        ],
+        "prob": 5
+      },
+      { "item": "essence_blood", "count": [ 2, 4 ], "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_spawn_raptor_unstable_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "item": "bone_twisted", "prob": 5 },
+      { "item": "essence_blood", "count": [ 2, 4 ], "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_spawn_raptor_electric_death_drops",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "vortex_shard", "prob": 50 },
+          { "item": "bone_twisted", "prob": 50 }
+        ],
+        "prob": 5
+      },
+      { "item": "essence_blood", "count": [ 2, 4 ], "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
     "id": "mon_zombie_thorny_death_drops",
     "//": "Adds to existing group",
     "subtype": "collection",

--- a/Arcana_BN/monsters/monster_overrides.json
+++ b/Arcana_BN/monsters/monster_overrides.json
@@ -72,6 +72,42 @@
     "death_drops": "mon_zombie_brute_ninja_death_drops"
   },
   {
+    "id": "mon_zombie_pupa_decoy_shady",
+    "copy-from": "mon_zombie_pupa_decoy_shady",
+    "type": "MONSTER",
+    "death_drops": "mon_zombie_pupa_decoy_shady_death_drops"
+  },
+  {
+    "id": "mon_zombie_pupa_shady",
+    "copy-from": "mon_zombie_pupa_shady",
+    "type": "MONSTER",
+    "death_drops": "mon_zombie_pupa_shady_death_drops"
+  },
+  {
+    "id": "mon_spawn_raptor",
+    "copy-from": "mon_spawn_raptor",
+    "type": "MONSTER",
+    "death_drops": "mon_spawn_raptor_death_drops"
+  },
+  {
+    "id": "mon_spawn_raptor_shady",
+    "copy-from": "mon_spawn_raptor_shady",
+    "type": "MONSTER",
+    "death_drops": "mon_spawn_raptor_shady_death_drops"
+  },
+  {
+    "id": "mon_spawn_raptor_unstable",
+    "copy-from": "mon_spawn_raptor_unstable",
+    "type": "MONSTER",
+    "death_drops": "mon_spawn_raptor_unstable_death_drops"
+  },
+  {
+    "id": "mon_spawn_raptor_electric",
+    "copy-from": "mon_spawn_raptor_electric",
+    "type": "MONSTER",
+    "death_drops": "mon_spawn_raptor_electric_death_drops"
+  },
+  {
     "id": "mon_zombie_biter",
     "copy-from": "mon_zombie_biter",
     "type": "MONSTER",


### PR DESCRIPTION
This adds monsterparts and essence to flesh raptors for the BN version. Self-PRing for now, set aside to merge when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2184 is merged.