### PR TITLE
Change vehicle energy_consumption to watts

### DIFF
--- a/Arcana/vehicleparts.json
+++ b/Arcana/vehicleparts.json
@@ -63,7 +63,7 @@
     "fuel_type": "battery",
     "durability": 150,
     "power": 200000,
-    "energy_consumption": "100 kJ",
+    "energy_consumption": "100 kW",
     "breaks_into": [
       { "item": "scrap", "count": [ 1, 4 ] },
       { "item": "steel_chunk", "count": [ 1, 3 ] },


### PR DESCRIPTION
Due to https://github.com/CleverRaven/Cataclysm-DDA/commit/89a86fc094b316fa8d8e23d7be6040a07cfe25cd