### PR TITLE
Convert remaining art-effects in BN version

### DIFF
--- a/Arcana_BN/items/tool_armor.json
+++ b/Arcana_BN/items/tool_armor.json
@@ -11,7 +11,7 @@
     "max_charges": 100,
     "charges_per_use": 20,
     "flags": [ "FANCY", "NO_RELOAD", "NO_UNLOAD", "TARDIS" ],
-    "artifact_data": { "charge_type": "ARTC_TIME" },
+    "relic_data": { "recharge_scheme": [ { "type": "time", "req": "none", "interval": "1 h", "rate": 1 } ] },
     "//": "Water talisman and earth talisman.  Each use has power equivalent to 200 mana.",
     "use_action": { "type": "cast_spell", "spell_id": "arcana_item_triffid_garland_empowered", "no_fail": true, "level": 0 }
   },
@@ -27,7 +27,7 @@
     "max_charges": 140,
     "charges_per_use": 28,
     "flags": [ "FANCY", "NO_RELOAD", "NO_UNLOAD", "TARDIS" ],
-    "artifact_data": { "charge_type": "ARTC_TIME" },
+    "relic_data": { "recharge_scheme": [ { "type": "time", "req": "none", "interval": "1 h", "rate": 1 } ] },
     "//": "Flame talisman and air talisman.  Each use has power equivalent to 280 mana.",
     "use_action": { "type": "cast_spell", "spell_id": "arcana_item_amulet_exotic_empowered", "no_fail": true, "level": 0 }
   },
@@ -43,7 +43,7 @@
     "max_charges": 180,
     "charges_per_use": 36,
     "flags": [ "FANCY", "NO_RELOAD", "NO_UNLOAD", "TARDIS" ],
-    "artifact_data": { "charge_type": "ARTC_TIME" },
+    "relic_data": { "recharge_scheme": [ { "type": "time", "req": "none", "interval": "1 h", "rate": 1 } ] },
     "//": "Earth talisman and air talisman.  Each use has power equivalent to 360 mana.",
     "use_action": { "type": "cast_spell", "spell_id": "arcana_item_brooch_iridescent_empowered", "no_fail": true, "level": 0 }
   },
@@ -782,8 +782,13 @@
     "charges_per_use": 1,
     "ammo": "essence_pure_type",
     "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_divine_seal", "no_fail": true, "need_worn": true, "level": 0 } ],
-    "artifact_data": { "charge_type": "ARTC_PORTAL", "effects_worn": [ "AEP_PSYSHIELD" ] },
-    "flags": [ "UNBREAKABLE_MELEE", "NO_SALVAGE", "NO_UNLOAD", "DIMENSIONAL_ANCHOR" ]
+    "relic_data": {
+      "recharge_scheme": [
+        { "type": "trap", "interval": "1 s", "rate": 1, "message": "The portal collapses!", "trap": "tr_portal" },
+        { "type": "field", "interval": "1 s", "rate": 0, "trap": "fd_fatigue" }
+      ]
+    },
+    "flags": [ "UNBREAKABLE_MELEE", "NO_SALVAGE", "NO_UNLOAD", "DIMENSIONAL_ANCHOR", "PSYSHIELD_PARTIAL" ]
   },
   {
     "id": "cleric_ring",
@@ -800,7 +805,6 @@
     "color": "white",
     "max_charges": 10,
     "ammo": "essence_type",
-    "artifact_data": { "effects_worn": [ "AEP_PSYSHIELD" ] },
     "use_action": {
       "target": "cleric_ring_on",
       "msg": "A strange energy radiates from the ring's gem, spreading a calming sensation over you.",
@@ -814,7 +818,7 @@
     "relic_data": {
       "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "ench_effects": [ { "effect": "cleric_warding", "intensity": 1 } ] } ]
     },
-    "extend": { "flags": [ "NO_SALVAGE" ] }
+    "extend": { "flags": [ "NO_SALVAGE", "PSYSHIELD_PARTIAL" ] }
   },
   {
     "id": "cleric_ring_on",

--- a/Arcana_BN/items/tools.json
+++ b/Arcana_BN/items/tools.json
@@ -101,7 +101,7 @@
     "max_charges": 80,
     "charges_per_use": 16,
     "flags": [ "MAGIC_FOCUS" ],
-    "artifact_data": { "charge_type": "ARTC_TIME" },
+    "relic_data": { "recharge_scheme": [ { "type": "time", "req": "none", "interval": "1 h", "rate": 1 } ] },
     "//": "Flame talisman and earth talisman.  Each use has power equivalent to 160 mana.",
     "use_action": { "type": "cast_spell", "spell_id": "arcana_item_charm_bone_empowered", "no_fail": true, "level": 0 }
   },
@@ -117,7 +117,7 @@
     "max_charges": 160,
     "charges_per_use": 32,
     "flags": [ "MAGIC_FOCUS" ],
-    "artifact_data": { "charge_type": "ARTC_TIME" },
+    "relic_data": { "recharge_scheme": [ { "type": "time", "req": "none", "interval": "1 h", "rate": 1 } ] },
     "//": "Water talisman and air talisman.  Each use has power equivalent to 320 mana.",
     "use_action": { "type": "cast_spell", "spell_id": "arcana_item_stinger_flute_empowered", "no_fail": true, "level": 0 }
   },
@@ -1971,12 +1971,12 @@
     "max_charges": 1,
     "charges_per_use": 1,
     "ammo": "essence_pure_type",
-    "artifact_data": { "effects_wielded": [ "AEP_SCHIZO" ] },
     "relic_data": {
       "passive_effects": [
         {
           "has": "WIELD",
           "condition": "ALWAYS",
+          "mutations": [ "SCHIZOPHRENIC" ],
           "ench_effects": [ { "effect": "arcana_clairvoyance_hidden", "intensity": 1 } ],
           "values": [
             { "value": "INTELLIGENCE", "add": 4 },
@@ -2378,7 +2378,6 @@
         "level": 0
       }
     ],
-    "artifact_data": { "charge_type": "ARTC_PORTAL" },
     "relic_data": {
       "passive_effects": [
         {
@@ -2386,10 +2385,14 @@
           "condition": "ALWAYS",
           "values": [ { "value": "INTELLIGENCE", "add": 4 }, { "value": "MANA_REGEN", "multiply": 0.5 } ]
         }
+      ],
+      "recharge_scheme": [
+        { "type": "trap", "interval": "1 s", "rate": 1, "message": "The portal collapses!", "trap": "tr_portal" },
+        { "type": "field", "interval": "1 s", "rate": 0, "trap": "fd_fatigue" }
       ]
     },
     "techniques": [ "WBLOCK_1", "WIDE", "BRUTAL", "SWEEP" ],
-    "flags": [ "UNBREAKABLE_MELEE", "NO_SALVAGE", "MAGIC_FOCUS", "NONCONDUCTIVE", "NO_UNLOAD", "SHEATH_SWORD" ]
+    "flags": [ "UNBREAKABLE_MELEE", "NO_SALVAGE", "MAGIC_FOCUS", "NONCONDUCTIVE", "SHEATH_SWORD" ]
   },
   {
     "id": "draconic_heart_mutator",


### PR DESCRIPTION
Work set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2284 is merged, easy enough. I need to prep one for Cata++ soon too.

Also includes phasing out AEP_PSYSHIELD in favor of the PSYSHIELD_PARTIAL flag, and calling for psychosis trait instead of using AEP_SCHIZO, as is done in the DDA version. Though my intent is for BN to have access to those features in some way via relicgen or item/effect flags later on, might as well just in case I forget prior to arti-effects finally getting phased out in favor of whatever relicgen implementation we're able to do in BN.