### PR TITLE
Arcana microlab_generic_tile variant generata a lot more often then any other

### DIFF
--- a/Arcana/overmap_and_mapgen/mapgen_variants.json
+++ b/Arcana/overmap_and_mapgen/mapgen_variants.json
@@ -1463,10 +1463,10 @@
   },
   {
     "type": "mapgen",
-    "om_terrain": [ [ "microlab_generic" ] ],
+    "nested_mapgen_id": "microlab_generic_tile",
     "method": "json",
     "object": {
-      "fill_ter": "t_strconc_floor",
+      "mapgensize": [ 24, 24 ],
       "rows": [
         "     |    |  2    | ccc ",
         " c c |6hh6|  |UUUU| RRR ",


### PR DESCRIPTION
Noticed it during my gamplay, confirmed it after fiddling with map editor a bit. This particular tile apreas way more often then any other. I changed it to be part of nested mapgen as other tiles and it seems to be fine now.
I only tested it with map editor tho, so probably need to see in actual game world as well to be sure
Edit: tested, was able to fine a few after a fix, not nearly as omnipresent as it used to be