### PR TITLE
Dragonblood mutation fixes

### DIFF
--- a/Arcana/mutations/mutations_dragonblood.json
+++ b/Arcana/mutations/mutations_dragonblood.json
@@ -393,7 +393,7 @@
     "type": "mutation",
     "id": "ARCANA_DRAGONTEETH",
     "name": { "str": "Pointed Teeth" },
-    "points": 2,
+    "points": 1,
     "visibility": 2,
     "ugliness": 2,
     "description": "Your teeth have changed into an assortment of pointed mimicries of human teeth, allowing you to make an extra attack when conditions favor it.",
@@ -414,7 +414,7 @@
     "type": "mutation",
     "id": "ARCANA_DRAGONMUZZLE",
     "name": { "str": "Draconic Muzzle" },
-    "points": -2,
+    "points": 2,
     "visibility": 4,
     "ugliness": 3,
     "mixed_effect": true,
@@ -493,7 +493,7 @@
         "attack_text_u": "You rake %s with your toe claws",
         "attack_text_npc": "%1$s rakes %2$s with their toe claws",
         "chance": 20,
-        "strength_damage": { "damage_type": "cut", "amount": 5 }
+        "strength_damage": { "damage_type": "cut", "amount": 4 }
       }
     ],
     "allowed_items": [ "ALLOWS_TALONS" ]


### PR DESCRIPTION
My preveous change made charecter unable to  get Draconic Muzzle without high instability as it is considered a negative trait, also made Draconic Hind Limbs equal to Toe Talons, as I underestimate how deadly they are for mutation tree that give a ton of strength