### PR TITLE
Pending BN Updates: Skill Achievement Improvements

### DIFF
--- a/Arcana_BN/achievements.json
+++ b/Arcana_BN/achievements.json
@@ -321,44 +321,30 @@
     "type": "achievement",
     "name": { "str": "<color_cyan>(Arcana)</color> Insight" },
     "description": "There are things mankind was not meant to learn.  And some things we were destined to learn.",
-    "requirements": [ { "event_statistic": "num_gains_arcana_level_5", "is": ">=", "target": 1 } ],
-    "//": "Entry-level skill achievements in BN are self-hidden, as starting with equal or higher skill in chargen skips them.",
-    "hidden_by": [ "achievement_lvl_5_arcana" ]
-  },
-  {
-    "id": "num_gains_arcana_level_5",
-    "type": "event_statistic",
-    "stat_type": "count",
-    "event_transformation": "avatar_gains_arcana_level_5",
-    "description": { "str_sp": "arcana skill level 5 gained" }
-  },
-  {
-    "id": "avatar_gains_arcana_level_5",
-    "type": "event_transformation",
-    "event_type": "gains_skill_level",
-    "value_constraints": { "character": { "equals_statistic": "avatar_id" }, "skill": { "equals": "magic" }, "new_level": { "equals": 5 } },
-    "drop_fields": [ "character", "skill", "new_level" ]
+    "skill_requirements": [ { "skill": "magic", "is": ">=", "level": 5 } ],
+    "requirements": [ { "event_statistic": "num_gains_arcana", "is": "anything" } ]
   },
   {
     "id": "achievement_lvl_10_arcana",
     "type": "achievement",
     "name": { "str": "<color_cyan>(Arcana)</color> Apprehension" },
     "description": "Seek not the things that are too high for thee.  But, it's in our nature to master the unknown.",
-    "requirements": [ { "event_statistic": "num_gains_arcana_level_10", "is": ">=", "target": 1 } ],
+    "skill_requirements": [ { "skill": "magic", "is": ">=", "level": 10 } ],
+    "requirements": [ { "event_statistic": "num_gains_arcana", "is": "anything" } ],
     "hidden_by": [ "achievement_lvl_5_arcana" ]
   },
   {
-    "id": "num_gains_arcana_level_10",
+    "id": "num_gains_arcana",
     "type": "event_statistic",
     "stat_type": "count",
-    "event_transformation": "avatar_gains_arcana_level_10",
-    "description": { "str_sp": "arcana skill level 10 gained" }
+    "event_transformation": "avatar_gains_arcana",
+    "description": { "str_sp": "arcana skill level up." }
   },
   {
-    "id": "avatar_gains_arcana_level_10",
+    "id": "avatar_gains_arcana",
     "type": "event_transformation",
     "event_type": "gains_skill_level",
-    "value_constraints": { "character": { "equals_statistic": "avatar_id" }, "skill": { "equals": "magic" }, "new_level": { "equals": 10 } },
-    "drop_fields": [ "character", "skill", "new_level" ]
+    "value_constraints": { "character": { "equals_statistic": "avatar_id" }, "skill": { "equals": "magic" } },
+    "drop_fields": [ "character", "skill" ]
   }
 ]


### PR DESCRIPTION
Set aside as a self-PR for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2613 is merged, using the new achievement format introduced in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2719 so that skill achievements don't shit themselves if you start with enough chargen skill to exceed the achievement's target skill level.