### PR TITLE
Pending BN update: The Lost And Damned

### DIFF
--- a/Arcana_BN/chargen/professions.json
+++ b/Arcana_BN/chargen/professions.json
@@ -636,5 +636,165 @@
       "female": [ "bra", "panties" ]
     },
     "traits": [ "PROF_ARCANIST" ]
+  },
+  {
+    "type": "profession",
+    "id": "prof_feral_magehunter",
+    "copy-from": "prof_feral_unemployed",
+    "name": "Feral Mage Hunter",
+    "description": "You were a member of The Cleansing Flame, a religious order.  The end of all has come.  You'll continue your order's work, purging every last heretic and consecrating every artifact, until there is nothing left.",
+    "points": 4,
+    "traits": [ "PROF_CLEANSINGFLAME", "PROF_FERAL" ],
+    "skills": [
+      { "level": 4, "name": "magic" },
+      { "level": 2, "name": "melee" },
+      { "level": 2, "name": "bashing" },
+      { "level": 1, "name": "dodge" }
+    ],
+    "items": {
+      "both": {
+        "items": [ "waterskin", "book_hexenhammer" ],
+        "entries": [
+          { "item": "dress_shirt", "damage": [ 0, 3 ] },
+          { "item": "gilded_aegis", "damage": [ 0, 3 ] },
+          { "item": "pants", "damage": [ 0, 3 ] },
+          { "item": "socks", "damage": [ 0, 3 ] },
+          { "item": "boots_larmor", "damage": [ 0, 3 ] },
+          { "item": "gauntlets_larmor", "damage": [ 0, 3 ] },
+          { "item": "helmet_galea", "damage": [ 0, 3 ] },
+          { "item": "somen_clairvoyance_xl", "damage": [ 0, 3 ] },
+          { "item": "backpack", "damage": [ 0, 3 ] },
+          { "item": "mana_gem_dull", "contents-group": "starting_mana_gem_237_dull_essence" },
+          { "item": "knife_hunting", "container-item": "sheath" },
+          { "item": "lucern_hexenhammer", "charges": [ 1, 10 ], "custom-flags": [ "auto_wield" ] }
+        ]
+      },
+      "male": { "entries": [ { "item": "boxer_shorts", "damage": [ 0, 3 ] } ] },
+      "female": { "entries": [ { "item": "sports_bra", "damage": [ 0, 3 ] }, { "item": "boy_shorts", "damage": [ 0, 3 ] } ] }
+    }
+  },
+  {
+    "type": "profession",
+    "id": "prof_feral_bloodmage",
+    "copy-from": "prof_feral_unemployed",
+    "name": "Feral Sanguinist",
+    "description": "You have beheld true power, as a member of the Sanguine Order.  No matter how many have bled for you, it just isn't enough.  You need more, to become stronger, to walk The Path.",
+    "points": 4,
+    "traits": [ "PROF_SANGUINE", "PROF_FERAL" ],
+    "skills": [
+      { "level": 3, "name": "magic" },
+      { "level": 1, "name": "firstaid" },
+      { "level": 1, "name": "gun" },
+      { "level": 1, "name": "melee" },
+      { "level": 1, "name": "stabbing" },
+      { "level": 1, "name": "dodge" }
+    ],
+    "items": {
+      "both": {
+        "items": [ "waterskin", "bowl_clay", "book_bloodmagic" ],
+        "entries": [
+          { "item": "dress_shirt", "damage": [ 0, 3 ] },
+          { "item": "socks", "damage": [ 0, 3 ] },
+          { "item": "armor_wyrm", "damage": [ 0, 3 ] },
+          { "item": "revenant_crown", "damage": [ 0, 3 ] },
+          { "item": "backpack", "damage": [ 0, 3 ] },
+          { "item": "mana_gem_blood", "contents-group": "starting_mana_gem_9_blood_essence" },
+          { "item": "blood_athame", "container-item": "sheath" },
+          {
+            "item": "bloodscourge",
+            "ammo-item": "essence_blood",
+            "charges": [ 1, 15 ],
+            "custom-flags": [ "auto_wield" ]
+          }
+        ]
+      },
+      "male": { "entries": [ { "item": "boxer_shorts", "damage": [ 0, 3 ] }, { "item": "pants", "damage": [ 0, 3 ] } ] },
+      "female": {
+        "entries": [
+          { "item": "bra", "damage": [ 0, 3 ] },
+          { "item": "panties", "damage": [ 0, 3 ] },
+          { "item": "skirt", "damage": [ 0, 3 ] }
+        ]
+      }
+    }
+  },
+  {
+    "type": "profession",
+    "id": "prof_feral_dark_priest",
+    "copy-from": "prof_feral_unemployed",
+    "name": "Feral Keeper",
+    "description": "He From Beyond The Veil calls to you.  But is it His call you heed, or that of an Interloper?  Maybe another sacrifice, another burnt offering, will clear the clouds from your mind.",
+    "points": 6,
+    "traits": [ "PROF_CHALICE", "PROF_FERAL" ],
+    "skills": [ { "level": 5, "name": "magic" }, { "level": 2, "name": "gun" }, { "level": 2, "name": "dodge" } ],
+    "items": {
+      "both": {
+        "items": [ "waterskin", "offering_chalice", "book_sacrifice" ],
+        "entries": [
+          { "item": "loincloth", "damage": [ 0, 3 ] },
+          { "item": "tunic", "damage": [ 0, 3 ] },
+          { "item": "robe_shadow_xl", "damage": [ 0, 3 ] },
+          { "item": "socks", "damage": [ 0, 3 ] },
+          { "item": "bastsandals", "damage": [ 0, 3 ] },
+          { "item": "gauntlets_necro_xl", "damage": [ 0, 3 ] },
+          { "item": "backpack", "damage": [ 0, 3 ] },
+          { "item": "cyclopean_mirror", "damage": [ 0, 3 ] },
+          { "item": "thunder_sigil", "container-item": "leather_belt" },
+          { "item": "mana_gem", "contents-group": "starting_mana_gem_7_essence" },
+          { "item": "copper_knife", "container-item": "sheath" },
+          {
+            "item": "spear_pestilence",
+            "ammo-item": "essence",
+            "charges": [ 1, 9 ],
+            "custom-flags": [ "auto_wield" ]
+          }
+        ]
+      },
+      "female": { "entries": [ { "item": "chestwrap", "damage": [ 0, 3 ] } ] }
+    }
+  },
+  {
+    "type": "profession",
+    "id": "prof_feral_summoner",
+    "copy-from": "prof_feral_unemployed",
+    "name": "Feral Summoner",
+    "description": "You were a student of a master arcanist, taught to draw power from beyond in living form, and bind it to your will.  You feel lost in a daze, urged on as though you were the puppet and not the master.",
+    "spells": [ { "id": "arcana_magic_summon_shadow", "level": 1 }, { "id": "arcana_magic_summon_shadow_snake", "level": 1 } ],
+    "points": 7,
+    "traits": [ "PROF_ARCANIST2", "PROF_FERAL" ],
+    "skills": [
+      { "level": 6, "name": "magic" },
+      { "level": 5, "name": "fabrication" },
+      { "level": 3, "name": "survival" },
+      { "level": 2, "name": "dodge" }
+    ],
+    "items": {
+      "both": {
+        "items": [
+          "waterskin",
+          "triffid_garland_empowered",
+          "bowl_pewter",
+          "summon_kreck_bound",
+          "summon_triffid_bound",
+          "monster_fang",
+          "wyrmskin_piece",
+          "book_summoning"
+        ],
+        "entries": [
+          { "item": "tunic", "damage": [ 0, 3 ] },
+          { "item": "cloak", "damage": [ 0, 3 ] },
+          { "item": "socks", "damage": [ 0, 3 ] },
+          { "item": "boots", "damage": [ 0, 3 ] },
+          { "item": "gloves_leather", "damage": [ 0, 3 ] },
+          { "item": "knit_scarf", "damage": [ 0, 3 ] },
+          { "item": "backpack", "damage": [ 0, 3 ] },
+          { "item": "knife_hunting", "container-item": "sheath" },
+          { "item": "mana_gem", "contents-group": "starting_mana_gem_14_essence" },
+          { "item": "i_staff", "custom-flags": [ "auto_wield" ] }
+        ]
+      },
+      "male": { "entries": [ { "item": "boxer_shorts", "damage": [ 0, 3 ] } ] },
+      "female": { "entries": [ { "item": "bra", "damage": [ 0, 3 ] }, { "item": "panties", "damage": [ 0, 3 ] } ] }
+    }
   }
 ]

--- a/Arcana_BN/chargen/scenarios.json
+++ b/Arcana_BN/chargen/scenarios.json
@@ -260,5 +260,28 @@
       ],
       "traits": [ "MARTIAL_ARTS_SANGUINE", "MARTIAL_ARTS_CF" ]
     }
+  },
+  {
+    "type": "scenario",
+    "id": "player_feral",
+    "copy-from": "player_feral",
+    "extend": {
+      "professions": [ "prof_feral_magehunter", "prof_feral_bloodmage", "prof_feral_dark_priest", "prof_feral_summoner" ],
+      "traits": [
+        "ARCANA_SCALYPATCHES",
+        "ARCANA_INNERHEAT",
+        "ARCANA_DRAGONCLAWS",
+        "ARCANA_DRAGONTEETH",
+        "ARCANA_DRAGONHORNS",
+        "SPELL_SHADOWSNAKES",
+        "SPELL_DAMPENING",
+        "SPELL_SUMMONDOG",
+        "SPELL_CLARITY",
+        "SPELL_DAYLIGHT",
+        "SPELL_LOCKPICK",
+        "MARTIAL_ARTS_SANGUINE",
+        "MARTIAL_ARTS_CF"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
This sets aside some stuff for when/if https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2892 is merged, adding content to inject into the new Lost And Damned scenario.

Profesions:
1. Feral mage hunter, based directly after the mage hunter profession but swapping in the variant gear that maddened hunters have a chance to drop instead.
2. Feral sanguinist, likewise an adaptation of the blood mage profession but adding some shrike gear which the maddened sanguinist can drop.
3. Feral keeper, adaptation adds in the spear of pestilence and cyclopean shield in addition to swapping in variants of the mantle and gauntlets.
4. Feral summoner, beefed up a bit from the basic version but otherwise not that divergent for a feral version of the summoner profession.

Scenario edit also adds in the option to start with relevant entry-level Dragonblood traits, a few thematically fitting Magic Signs, or the relevant martial arts.