### PR TITLE
Pending BN update: anvil usage overhaul

### DIFF
--- a/Arcana/recipes/recipe_weapon.json
+++ b/Arcana/recipes/recipe_weapon.json
@@ -470,7 +470,7 @@
     "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" } ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "swage", -1 ] ], [ [ "book_bloodmagic", -1 ] ] ],
+    "tools": [ [ [ "book_bloodmagic", -1 ] ] ],
     "components": [
       [ [ "silver_small", 500 ] ],
       [ [ "2x4", 1 ], [ "stick", 1 ] ],

--- a/Arcana_BN/recipes/recipe_magitech.json
+++ b/Arcana_BN/recipes/recipe_magitech.json
@@ -10,8 +10,8 @@
     "difficulty": 4,
     "time": "45 m",
     "book_learn": [ [ "recipe_lab_arcana", 4 ], [ "book_syncretism", 4 ], [ "recipe_lab_elec", 5 ], [ "book_hexenhammer", 5 ] ],
-    "using": [ [ "blacksmithing_standard", 1 ], [ "surface_heat", 2 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 }, { "id": "CHEM", "level": 2 } ],
+    "using": [ [ "blacksmithing_intermediate", 1 ], [ "surface_heat", 2 ] ],
+    "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [
       [ [ "essence_blood", 2 ], [ "essence_dull", 20 ] ],
@@ -32,8 +32,8 @@
     "difficulty": 4,
     "time": "1 h",
     "book_learn": [ [ "recipe_lab_arcana", 4 ], [ "book_syncretism", 4 ], [ "recipe_lab_elec", 5 ], [ "book_hexenhammer", 5 ] ],
-    "using": [ [ "blacksmithing_standard", 3 ], [ "surface_heat", 6 ], [ "arcana_essence_any", 2 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 }, { "id": "CHEM", "level": 2 } ],
+    "using": [ [ "blacksmithing_intermediate", 3 ], [ "surface_heat", 6 ], [ "arcana_essence_any", 2 ] ],
+    "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "salt", 15 ] ], [ [ "copper", 9 ] ], [ [ "lye_powder", 6 ] ], [ [ "steel_chunk", 3 ], [ "scrap", 6 ] ] ]
   },
@@ -48,8 +48,8 @@
     "difficulty": 4,
     "time": "1 h 20 m",
     "book_learn": [ [ "recipe_lab_arcana", 4 ], [ "book_syncretism", 4 ], [ "recipe_lab_elec", 5 ], [ "book_hexenhammer", 5 ] ],
-    "using": [ [ "blacksmithing_standard", 12 ], [ "surface_heat", 24 ], [ "arcana_essence_any", 8 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 }, { "id": "CHEM", "level": 2 } ],
+    "using": [ [ "surface_heat", 24 ], [ "arcana_essence_any", 8 ] ],
+    "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "salt", 60 ] ], [ [ "copper", 36 ] ], [ [ "lye_powder", 24 ] ], [ [ "steel_chunk", 12 ], [ "scrap", 24 ] ] ]
   },
@@ -64,8 +64,8 @@
     "difficulty": 4,
     "time": "1 h 45 m",
     "book_learn": [ [ "recipe_lab_arcana", 4 ], [ "book_syncretism", 4 ], [ "recipe_lab_elec", 5 ], [ "book_hexenhammer", 5 ] ],
-    "using": [ [ "blacksmithing_standard", 25 ], [ "surface_heat", 50 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 }, { "id": "CHEM", "level": 2 } ],
+    "using": [ [ "blacksmithing_intermediate", 25 ], [ "surface_heat", 50 ] ],
+    "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [
       [ [ "essence_blood", 50 ], [ "essence_dull", 500 ] ],
@@ -463,8 +463,7 @@
     "difficulty": 8,
     "time": "25 m",
     "book_learn": [ [ "recipe_lab_arcana", 8 ], [ "book_sacrifice", 9 ], [ "book_syncretism", 9 ] ],
-    "using": [ [ "blacksmithing_standard", 25 ], [ "steel_tiny", 5 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
+    "using": [ [ "blacksmithing_intermediate", 25 ], [ "steel_tiny", 5 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [
       [ [ "offering_chalice", 1 ] ],

--- a/Arcana_BN/recipes/recipe_weapon.json
+++ b/Arcana_BN/recipes/recipe_weapon.json
@@ -422,9 +422,9 @@
     "skills_required": [ [ "fabrication", 7 ], [ "mechanics", 4 ], [ "pistol", 3 ] ],
     "time": "120 m",
     "book_learn": [ [ "book_bloodmagic", 7 ] ],
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "swage", -1 ] ], [ [ "book_bloodmagic", -1 ] ] ],
+    "using": [ [ "blacksmithing_intermediate", 2 ], [ "steel_tiny", 2 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
+    "tools": [ [ [ "book_bloodmagic", -1 ] ] ],
     "components": [
       [ [ "silver_small", 500 ] ],
       [ [ "2x4", 1 ], [ "stick", 1 ] ],


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3008 is merged, phasing in usage of the new tiers of blacksmithing 

Also shifts shrike's misericorde to not use a swage and die since mostly made of silver, contains a slight tweak to the DDA version of the recipe accordingly.