### PR TITLE
Pending BN Update: Mutation Flag JSON

### DIFF
--- a/Arcana_BN/mutations/mutations_other.json
+++ b/Arcana_BN/mutations/mutations_other.json
@@ -1,5 +1,9 @@
 [
   {
+    "id": "explorer_of_the_veil",
+    "type": "mutation_flag"
+  },
+  {
     "type": "mutation",
     "id": "MARTIAL_ARTS_CF",
     "name": { "str": "Path of Sword and Hammer" },


### PR DESCRIPTION
Set aside as a draft for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2911 is merged, as now custom dialogue flags for mutations need their own definitions as `mutation_flags` entries.