### PR TITLE
Fix charges -> counts and adds deleted item groups to give CDDA compatability

### DIFF
--- a/Arcana/chargen/professions.json
+++ b/Arcana/chargen/professions.json
@@ -598,7 +598,7 @@
         "entries": [
           { "item": "spear_pestilence", "ammo-item": "essence", "charges": 9, "container-item": "spearsling" },
           { "item": "mana_gem", "contents-group": "starting_mana_gem_11_essence" },
-          { "item": "salt", "container-item": "bag_canvas_small", "charges": 100 },
+          { "item": "salt", "container-item": "bag_canvas_small", "count": 100 },
           { "group": "charged_candle" },
           { "item": "sewing_kit", "charges": 50 },
           { "item": "copper_knife", "container-item": "sheath" }

--- a/Arcana/item_groups/item_groups_chalice.json
+++ b/Arcana/item_groups/item_groups_chalice.json
@@ -108,7 +108,7 @@
       { "item": "gold_small", "prob": 40, "charges": [ 25, 100 ] },
       { "item": "scrap", "prob": 15, "count": [ 1, 10 ] },
       { "item": "feather", "prob": 5, "charges": [ 10, 20 ] },
-      { "item": "chitin_piece", "prob": 5, "charges": [ 1, 5 ] },
+      { "item": "chitin_piece", "prob": 5, "count": [ 1, 5 ] },
       { "item": "fur", "prob": 10, "count": [ 1, 5 ] },
       { "item": "paper", "prob": 5, "charges": [ 20, 50 ] },
       [ "bee_sting", 10 ],

--- a/Arcana/item_groups/item_groups_cleansingflame.json
+++ b/Arcana/item_groups/item_groups_cleansingflame.json
@@ -307,8 +307,8 @@
       [ "strength_potion", 15 ],
       [ "speed_potion", 10 ],
       [ "healing_potion", 10 ],
-      { "item": "red_black_vulnerary", "prob": 5, "charges": 2 },
-      { "item": "yellow_white_incense", "prob": 5, "charges": 2 }
+      { "item": "red_black_vulnerary", "prob": 5, "count": 2 },
+      { "item": "yellow_white_incense", "prob": 5, "count": 2 }
     ]
   },
   {
@@ -328,17 +328,17 @@
     "id": "rural_church_hunter_haul",
     "type": "item_group",
     "items": [
-      { "item": "meat_pickled", "prob": 25, "charges": 2, "container-item": "jar_glass_sealed" },
-      { "item": "meat_smoked", "prob": 10, "charges": 2, "container-item": "wrapper" },
-      { "item": "jerky", "prob": 10, "charges": 4, "container-item": "wrapper" },
-      { "item": "sausage", "prob": 10, "charges": 2, "container-item": "wrapper" },
-      { "item": "sausage_wasteland", "prob": 10, "charges": 2, "container-item": "wrapper" },
-      { "item": "cracklins", "prob": 5, "charges": 8, "container-item": "wrapper" },
-      { "item": "tallow", "prob": 5, "charges": 2, "container-item": "wrapper" },
-      { "item": "lard", "prob": 5, "charges": 2, "container-item": "wrapper" },
-      { "item": "cured_pelt", "prob": 10, "charges": [ 1, 5 ] },
-      { "item": "cured_hide", "prob": 10, "charges": [ 1, 5 ] },
-      { "item": "bone", "prob": 5, "charges": [ 1, 5 ] },
+      { "prob": 25, "group": "meat_pickled_jar_glass_sealed_2" },
+      { "item": "meat_smoked", "prob": 10, "count": 2, "container-item": "wrapper" },
+      { "item": "jerky", "prob": 10, "count": 4, "container-item": "wrapper" },
+      { "item": "sausage", "prob": 10, "count": 2, "container-item": "wrapper" },
+      { "item": "sausage_wasteland", "prob": 10, "count": 2, "container-item": "wrapper" },
+      { "item": "cracklins", "prob": 5, "count": 8, "container-item": "wrapper" },
+      { "item": "tallow", "prob": 5, "count": 2, "container-item": "wrapper" },
+      { "item": "lard", "prob": 5, "count": 2, "container-item": "wrapper" },
+      { "item": "cured_pelt", "prob": 10, "count": [ 1, 5 ] },
+      { "item": "cured_hide", "prob": 10, "count": [ 1, 5 ] },
+      { "item": "bone", "prob": 5, "count": [ 1, 5 ] },
       { "item": "broth_bone", "prob": 5, "charges": 2, "container-item": "jar_glass_sealed" }
     ]
   },

--- a/Arcana/item_groups/item_groups_general.json
+++ b/Arcana/item_groups/item_groups_general.json
@@ -118,8 +118,8 @@
       [ "strength_potion", 40 ],
       [ "speed_potion", 35 ],
       [ "healing_potion", 30 ],
-      { "item": "red_black_vulnerary", "prob": 25, "charges": 2 },
-      { "item": "yellow_white_incense", "prob": 20, "charges": 2 },
+      { "item": "red_black_vulnerary", "prob": 25, "count": 2 },
+      { "item": "yellow_white_incense", "prob": 20, "count": 2 },
       [ "scroll_sun", 25 ],
       [ "scroll_moon", 25 ],
       [ "scroll_artiface", 20 ],
@@ -317,11 +317,11 @@
     "//": "A smattering of non-magitech tools and materials of anomalous origin.",
     "type": "item_group",
     "items": [
-      { "item": "meat_frond", "prob": 10, "charges": 2, "container-item": "jar_glass_sealed" },
-      { "item": "leech_flower", "prob": 5, "charges": 2, "container-item": "jar_glass_sealed" },
-      { "item": "meat_bark", "prob": 5, "charges": 2, "container-item": "jar_glass_sealed" },
-      { "item": "veggy_tainted", "prob": 15, "charges": 2, "container-item": "jar_glass_sealed" },
-      { "item": "veggy", "prob": 15, "charges": 2, "container-item": "jar_glass_sealed" },
+      { "item": "meat_frond", "prob": 10, "count": 2, "container-item": "jar_glass_sealed" },
+      { "item": "leech_flower", "prob": 5, "count": 2, "container-item": "jar_glass_sealed" },
+      { "item": "meat_bark", "prob": 5, "count": 2, "container-item": "jar_glass_sealed" },
+      { "item": "veggy_tainted", "prob": 15, "count": 2, "container-item": "jar_glass_sealed" },
+      { "item": "veggy", "prob": 15, "count": 2, "container-item": "jar_glass_sealed" },
       [ "stick_fiber", 4 ],
       [ "fighter_sting", 3 ],
       [ "biollante_bud", 3 ],
@@ -425,6 +425,45 @@
         "distribution": [ { "group": "magic_tools", "prob": 75 }, { "group": "magic_items", "prob": 25 } ],
         "prob": 10
       }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mine_storage",
+    "items": [
+      [ "shovel", 10 ],
+      [ "pickaxe", 2 ],
+      [ "bucket", 20 ],
+      [ "rock", 40 ],
+      [ "rock_large", 10 ],
+      { "group": "tools_toolbox", "prob": 5 },
+      [ "coal_lump", 20 ],
+      [ "material_shrd_limestone", 40 ],
+      [ "material_niter", 5 ],
+      [ "chem_rdx", 5 ],
+      [ "chem_hmtd", 10 ]
+    ]
+  },
+  {
+    "id": "sewing_room",
+    "type": "item_group",
+    "subtype": "distribution",
+    "items": [
+      { "group": "suits", "prob": 50, "damage": [ 0, 2 ] },
+      [ "scissors", 50 ],
+      [ "thread", 50 ],
+      { "group": "pants", "prob": 40, "damage": [ 0, 2 ] },
+      { "group": "shirts", "prob": 40, "damage": [ 0, 2 ] },
+      [ "knitting_needles", 40 ],
+      [ "string_36", 40 ],
+      [ "yarn", 40 ],
+      { "group": "bed", "prob": 30, "damage": [ 0, 2 ] },
+      { "item": "sewing_kit", "prob": 30, "charges": [ 0, 25 ] },
+      [ "cotton_patchwork", 30 ],
+      [ "lycra_patch", 15 ],
+      [ "nylon", 10 ],
+      { "item": "tailors_kit", "prob": 20, "charges": [ 0, 100 ] },
+      [ "kevlar_shears", 5 ]
     ]
   }
 ]

--- a/Arcana/item_groups/item_groups_sanguine.json
+++ b/Arcana/item_groups/item_groups_sanguine.json
@@ -118,7 +118,7 @@
       [ "pearl", 3 ],
       [ "diamond", 2 ],
       { "item": "scrap", "prob": 5, "count": [ 1, 10 ] },
-      { "item": "leather", "prob": 15, "charges": [ 10, 20 ] },
+      { "item": "leather", "prob": 15, "count": [ 10, 20 ] },
       [ "chem_nitric_acid", 10 ],
       { "item": "bone_human", "prob": 15, "count": [ 1, 5 ] },
       [ "chem_ethanol", 5 ],

--- a/Arcana/monsters/monster_drops.json
+++ b/Arcana/monsters/monster_drops.json
@@ -2105,7 +2105,7 @@
     "entries": [
       { "item": "arcana_mech_shem" },
       { "item": "scrap", "charges": [ 0, 35 ] },
-      { "item": "e_scrap", "charges": [ 0, 2 ] },
+      { "item": "e_scrap", "count": [ 0, 2 ] },
       { "item": "copper", "charges": [ 0, 350 ] },
       { "item": "wire", "count": [ 0, 2 ] },
       { "item": "amplifier", "count": [ 0, 2 ] },

--- a/Arcana/npcs/NC_FILES.json
+++ b/Arcana/npcs/NC_FILES.json
@@ -1158,7 +1158,7 @@
       { "item": "kevlar" },
       { "item": "jersey" },
       { "item": "jacket_leather_mod" },
-      { "item": "bandolier_shotgun", "charges": 25, "contents-item": "reloaded_shot_00_arcana" },
+      { "item": "reloaded_shot_00_arcana", "charges": 25, "container-item": "bandolier_shotgun" },
       { "item": "boxer_shorts" },
       { "item": "jeans" },
       { "item": "gloves_fingerless_mod" },


### PR DESCRIPTION
Shifts items to spawn with 'count' instead of 'charges' as charges have been deprecated in CDDA
Adds "sewing_room" and "mine_storage" itemgroups to generic file as these groups have been deleted from CDDA but are still used in Arcana