### PR TITLE
Group Arcana skill with other interaction skills

### DIFF
--- a/Arcana/skills.json
+++ b/Arcana/skills.json
@@ -8,7 +8,7 @@
     "time_to_attack": { "min_time": 30, "base_time": 100, "time_reduction_per_level": 7 },
     "companion_survival_rank_factor": 1,
     "display_category": "display_interaction",
-    "sort_rank": 14500,
+    "sort_rank": 26400,
     "companion_skill_practice": [ { "skill": "hunting", "weight": 1 }, { "skill": "combat", "weight": 1 } ]
   }
 ]


### PR DESCRIPTION
Currently the Arcana skill is between the ranged and crafting skills while being an interaction skill.

Issue (metaphysics and spellcraft are mod skills):
![arcana skill sorting](https://github.com/chaosvolt/cdda-arcana-mod/assets/70666939/86a9d6de-9aee-42d5-8248-5f44b77903a1)

Fix:
![arcana skill sorting fixed](https://github.com/chaosvolt/cdda-arcana-mod/assets/70666939/b9b0c096-02de-4b4d-8c3d-35ae0e6b49ea)
