### PR TITLE
Remove powerful_knockback field from DDA techniques

### DIFF
--- a/Arcana/techniques.json
+++ b/Arcana/techniques.json
@@ -208,7 +208,6 @@
       { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.5 }
     ],
     "knockback_dist": 3,
-    "powerful_knockback": true,
     "down_dur": 1,
     "crit_tec": true,
     "weighting": 2,


### PR DESCRIPTION
https://github.com/CleverRaven/Cataclysm-DDA/pull/68418 removed the powerful_knockback field.

The field didn't do anything even before deprecation, so I'm following 68418 as an example by not replacing the field with anything.