### PR TITLE
Remove Spell Classes from Magic Signs

### DIFF
--- a/Arcana/spells/spells_magic_signs.json
+++ b/Arcana/spells/spells_magic_signs.json
@@ -27,7 +27,7 @@
     "min_duration": 144000,
     "max_duration": 288000,
     "duration_increment": 14400,
-    "spell_class": "SPELL_AGILE"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_capacitance",
@@ -57,7 +57,8 @@
     "skill": "magic",
     "base_casting_time": 240,
     "final_casting_time": 120,
-    "casting_time_increment": -12
+    "casting_time_increment": -12,
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_clairvoyance",
@@ -86,7 +87,7 @@
     "min_duration": 216000,
     "max_duration": 432000,
     "duration_increment": 21600,
-    "spell_class": "SPELL_CLAIRVOYANCE"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_clarity_blood",
@@ -116,7 +117,7 @@
     "min_duration": 48000,
     "max_duration": 96000,
     "duration_increment": 4800,
-    "spell_class": "SPELL_CLARITY"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_cold_ward",
@@ -145,7 +146,8 @@
     "energy_increment": -150,
     "min_duration": 60000,
     "max_duration": 120000,
-    "duration_increment": 6000
+    "duration_increment": 6000,
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_confuse_monster",
@@ -176,7 +178,7 @@
     "min_duration": 1800,
     "max_duration": 3600,
     "duration_increment": 180,
-    "spell_class": "SPELL_CONFUSE"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_conjure_acid",
@@ -224,7 +226,7 @@
     "max_field_intensity": 3,
     "field_intensity_increment": 0.2,
     "field_intensity_variance": 0.5,
-    "spell_class": "SPELL_ACID"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_conjure_flame",
@@ -272,7 +274,7 @@
     "max_field_intensity": 3,
     "field_intensity_increment": 0.2,
     "field_intensity_variance": 0.5,
-    "spell_class": "SPELL_FIRE"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_consecrate",
@@ -307,7 +309,8 @@
     "casting_time_increment": -14,
     "base_energy_cost": 3500,
     "final_energy_cost": 1750,
-    "energy_increment": -175
+    "energy_increment": -175,
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_dark_lance",
@@ -344,7 +347,8 @@
     "field_id": "fd_fog",
     "field_chance": 3,
     "min_field_intensity": 1,
-    "max_field_intensity": 1
+    "max_field_intensity": 1,
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_dampening",
@@ -384,7 +388,7 @@
     "max_field_intensity": 3,
     "field_intensity_increment": 0.2,
     "field_intensity_variance": 0.5,
-    "spell_class": "SPELL_DAMPENING"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_earthweaving",
@@ -412,7 +416,8 @@
     "casting_time_increment": -10,
     "base_energy_cost": 2500,
     "final_energy_cost": 1250,
-    "energy_increment": -125
+    "energy_increment": -125,
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_eclipse",
@@ -444,7 +449,8 @@
     "energy_increment": -250,
     "min_duration": 324000,
     "max_duration": 648000,
-    "duration_increment": 32400
+    "duration_increment": 32400,
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_elemental_burst",
@@ -479,7 +485,8 @@
     "energy_source": "STAMINA",
     "base_energy_cost": 4000,
     "final_energy_cost": 2000,
-    "energy_increment": -200
+    "energy_increment": -200,
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_free_action",
@@ -512,7 +519,7 @@
     "min_duration": 36000,
     "max_duration": 72000,
     "duration_increment": 3600,
-    "spell_class": "SPELL_FREEACTION"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_harden_senses",
@@ -541,7 +548,8 @@
     "energy_increment": -75,
     "min_duration": 24000,
     "max_duration": 48000,
-    "duration_increment": 2400
+    "duration_increment": 2400,
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_healing",
@@ -576,7 +584,7 @@
     "min_duration": 100,
     "max_duration": 100,
     "energy_source": "STAMINA",
-    "spell_class": "SPELL_HEAL"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_heat_ward",
@@ -606,7 +614,7 @@
     "min_duration": 60000,
     "max_duration": 120000,
     "duration_increment": 6000,
-    "spell_class": "SPELL_FLAMEARMOR"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_insight",
@@ -636,7 +644,7 @@
     "min_duration": 108000,
     "max_duration": 216000,
     "duration_increment": 10800,
-    "spell_class": "SPELL_INSIGHT"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_light",
@@ -672,7 +680,7 @@
     "field_chance": 2,
     "min_field_intensity": 1,
     "max_field_intensity": 1,
-    "spell_class": "SPELL_LIGHT"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_lightning_ward",
@@ -702,7 +710,7 @@
     "min_duration": 48000,
     "max_duration": 96000,
     "duration_increment": 4800,
-    "spell_class": "SPELL_ELECRESIST"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_might",
@@ -732,7 +740,7 @@
     "min_duration": 180000,
     "max_duration": 360000,
     "duration_increment": 18000,
-    "spell_class": "SPELL_STRENGTH"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_open_lock",
@@ -768,7 +776,7 @@
     "base_energy_cost": 2500,
     "final_energy_cost": 1250,
     "energy_increment": -125,
-    "spell_class": "SPELL_LOCKPICK"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_overgrowth",
@@ -800,7 +808,8 @@
     "casting_time_increment": -8,
     "base_energy_cost": 2000,
     "final_energy_cost": 1000,
-    "energy_increment": -100
+    "energy_increment": -100,
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_phase_shield",
@@ -828,7 +837,8 @@
     "energy_increment": -200,
     "min_duration": 84000,
     "max_duration": 168000,
-    "duration_increment": 8400
+    "duration_increment": 8400,
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_poison_armor",
@@ -858,7 +868,7 @@
     "min_duration": 36000,
     "max_duration": 72000,
     "duration_increment": 3600,
-    "spell_class": "SPELL_POISONARMOR"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_serpentine_shield",
@@ -888,7 +898,7 @@
     "min_duration": 72000,
     "max_duration": 144000,
     "duration_increment": 7200,
-    "spell_class": "SPELL_SHADOWSNAKES"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_shockstorm",
@@ -937,7 +947,7 @@
     "max_field_intensity": 3,
     "field_intensity_increment": 0.2,
     "field_intensity_variance": 0.5,
-    "spell_class": "SPELL_PLANTS"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_sundering_quake",
@@ -975,7 +985,8 @@
     "casting_time_increment": -18,
     "base_energy_cost": 4500,
     "final_energy_cost": 2250,
-    "energy_increment": -225
+    "energy_increment": -225,
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_summon_giant_centipedes",
@@ -1009,7 +1020,8 @@
     "energy_increment": -175,
     "min_duration": 720000,
     "max_duration": 1440000,
-    "duration_increment": 72000
+    "duration_increment": 72000,
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_summon_skeletal_dog",
@@ -1041,7 +1053,7 @@
     "min_duration": 360000,
     "max_duration": 720000,
     "duration_increment": 36000,
-    "spell_class": "SPELL_SUMMONDOG"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_summon_shadow",
@@ -1072,7 +1084,8 @@
     "energy_increment": -150,
     "min_duration": 600000,
     "max_duration": 1200000,
-    "duration_increment": 60000
+    "duration_increment": 60000,
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_summon_shadow_snake",
@@ -1104,7 +1117,8 @@
     "energy_increment": -175,
     "min_duration": 720000,
     "max_duration": 1440000,
-    "duration_increment": 72000
+    "duration_increment": 72000,
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_surge_adrenaline",
@@ -1134,7 +1148,7 @@
     "max_duration": 144000,
     "duration_increment": 7200,
     "energy_source": "STAMINA",
-    "spell_class": "SPELL_DAYLIGHT"
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_temporal_aura",
@@ -1163,7 +1177,8 @@
     "energy_source": "STAMINA",
     "base_energy_cost": 4500,
     "final_energy_cost": 2250,
-    "energy_increment": -225
+    "energy_increment": -225,
+    "spell_class": "NONE"
   },
   {
     "id": "arcana_magic_ward_against_evil",
@@ -1193,6 +1208,6 @@
     "min_duration": 60000,
     "max_duration": 120000,
     "duration_increment": 6000,
-    "spell_class": "SPELL_CLERIC"
+    "spell_class": "NONE"
   }
 ]


### PR DESCRIPTION
Context:
CDDA added a feature where the spell menu allows sorting by spell class, ex:
![Spell Class](https://github.com/chaosvolt/cdda-arcana-mod/assets/70666939/c3aa8517-270c-4ac8-832e-8c5f98a3da92)
Since many of the spell signs have unique spell classes, this massively clutters the menu with many individual tabs for each sign.  Removing the classes fixes this.

I created a character with the removed classes and they still spawn with the correct spells when added via profession / chargen traits:
![classless](https://github.com/chaosvolt/cdda-arcana-mod/assets/70666939/cbab227b-d1a8-4ae4-8335-f2da2365da72)
