### PR TITLE
Add 'manual' category to skillbooks

### DIFF
--- a/Arcana/items/books.json
+++ b/Arcana/items/books.json
@@ -2,6 +2,7 @@
   {
     "id": "book_magicfordummies",
     "type": "BOOK",
+    "category": "manuals",
     "name": { "str": "Apprentice's Notes", "str_pl": "copies of Apprentice's Notes" },
     "description": "A series of handwritten notes by a student of some esoteric order.  At first the subject seems to be simple religious rituals, but it soon delves into more …anomalous practices.\n\"In time, my eyes will be opened.  They called it The Gift, but all who draw breath can partake of it.  There is no innate talent, no quirk of bloodline, only discipline and patience…\"",
     "weight": "454 g",
@@ -23,6 +24,7 @@
   {
     "id": "book_potioncraft",
     "type": "BOOK",
+    "category": "manuals",
     "name": { "str": "History of Alchemy", "str_pl": "copies of History of Alchemy" },
     "description": "A series of translated, annotated excerpts from several ancient books on the concept of alchemy.  This book presents an unconventional interpretation of the works discussed, haphazardly segueing into the author's own failed attempt to create the \"lapis philosophorum\" and \"alkahest\".  Some of the unconventional chemistry discussed might still be useful.\n\"Through all the cycles of putrefaction and purification, we have fallen short of refinement into the Rubedo stage.  We are missing a catalyst, something even purer than gold, energy embodied in matter…\"",
     "weight": "454 g",
@@ -43,6 +45,7 @@
   {
     "id": "book_scrollcraft",
     "type": "BOOK",
+    "category": "manuals",
     "name": { "str": "The Six Pillars", "str_pl": "copies of The Six Pillars" },
     "//": "Implies that interpreting the coded verses are the most difficult part, the magic itself is low-mid level in complexity.",
     "description": "A book depicting six strange symbols on the cover.  The text uses mythological concepts and metaphors to disguise magical formulae, concealing its knowledge within stories of an otherworldly pantheon.\n\"Mother of the sun.  Maiden of moonlit storms.  Order woven into earth itself.  Chaos reveling in nature.  Four horsemen embodied as one.  Defiance and strife.  You are the keepers of all I know…\"",
@@ -65,6 +68,7 @@
   {
     "id": "book_bloodmagic",
     "type": "BOOK",
+    "category": "manuals",
     "name": { "str": "Sanguine Codex", "str_pl": "copies of Sanguine Codex" },
     "description": "A book written in dark, brown ink that almost resembles dried blood.  It illustrates several painful-looking rituals for drawing powerful energy from the blood of living creatures, the practices of an order of blood mages.\n\"There is power in life itself.  There is a struggle, turmoil and chaos in it as well.  To follow The Path requires making proper use of said disharmony, even as one draws power from life…\"",
     "weight": "454 g",
@@ -85,6 +89,7 @@
   {
     "id": "book_hexenhammer",
     "type": "BOOK",
+    "category": "manuals",
     "name": { "str": "The Cleansing Flame", "str_pl": "copies of The Cleansing Flame" },
     "description": "A book written by some esoteric religious order, dedicated to destroying the otherworldly things intruding upon this realm.  The tools of their trade rely on a sanctioned form of magic, using \"consecrated\" essence they deemed safe to use.\n\"To bring justice to those who would endanger humanity, if we must.  To mend the growing wound In The Veil Between Worlds, if we can.  To guard and guide, so that a dangerous path may be avoided, so we shall.  So long as the Sun shines upon the Earth.\"",
     "weight": "454 g",
@@ -106,6 +111,7 @@
   {
     "id": "book_sacrifice",
     "type": "BOOK",
+    "category": "manuals",
     "name": { "str": "Oaths to the Chalice", "str_pl": "copies of Oaths to the Chalice" },
     "description": "A strange book with a trident motif on the cover, describing the morbid rituals of some otherworldly cult, preaching of He From Beyond The Veil.  The level of detail these rituals go into is disturbing, yet informative.\n\"Through my visions, I saw rolling fog sweep across the valleys of a thousand worlds.  I witnessed the decay of countless cities, built by endless unnamed things.  And there, shadows coalesced into form, a presence to guide me…\"",
     "weight": "454 g",
@@ -127,6 +133,7 @@
   {
     "id": "book_syncretism",
     "type": "BOOK",
+    "category": "manuals",
     "name": { "str": "A Story in Shadow", "str_pl": "copies of A Story in Shadow" },
     "description": "A book discussing the histories of a few peculiar cults and religious orders, and their conflicts during the years up until shortly before the cataclysm.  It describes a number of peculiar rituals and concepts based on the philosophies of the major groups mentioned, along with musing on their respective strengths and flaws.\n\"Athame, hammer, and chalice.  Stalking and warring over trifling powers, as the Blind World pursued the End of All.  All things are, and shall be, as was written…\"",
     "weight": "454 g",
@@ -147,6 +154,7 @@
   {
     "id": "book_summoning",
     "type": "BOOK",
+    "category": "manuals",
     "name": { "str": "To Master the Unknown", "str_pl": "copies of To Master the Unknown" },
     "description": "A book describing several otherworldly creatures and their origins, or at least conjecture on those origins.  Stranger still, it describes experiments in summoning and  …controlling them?\n\"In the absence of an adequate catalyst, those who dwell Beyond are not easily called into service.  What slips through the cracks most readily is a mere shadow, a reflection of shadows even, given form that can be tamed…\"",
     "weight": "454 g",
@@ -167,6 +175,7 @@
   {
     "id": "recipe_lab_arcana",
     "type": "BOOK",
+    "category": "manuals",
     "name": { "str": "lab journal-Quinn", "str_pl": "lab journals-Quinn" },
     "description": "This hefty binder contains numerous reports concerning Anomalous Materials research, and experiment logs involving various otherworldly phenomena.  Some effort was made to hypothesize on the physics involved behind the events that occurred, though the writing's tone conveys a growing frustration with the increasingly supernatural nature of each discovery…",
     "weight": "2000 g",
@@ -521,6 +530,7 @@
   {
     "id": "arcana_mech_shem",
     "type": "BOOK",
+    "category": "manuals",
     "name": { "str": "Z-07 Engraved Plate" },
     "description": "A warped sheet of exotic metal, covered in esoteric engravings.  The patterns depicted on it resemble astrological imagery and alchemical formulas, with fragments of legible writing encircling the outer edge of the design.  On closer inspection, parts of the engraving appear to resemble technical drawings and schematics for the very machine it was torn from, either for some ritual purpose that helped give it life, or for some unknown research purpose.  Someone skilled in otherworldly knowledge might be able to glean something useful from this.",
     "weight": "10800 g",

--- a/Patchmods/BN_Arcana_Cata++_Patch/books.json
+++ b/Patchmods/BN_Arcana_Cata++_Patch/books.json
@@ -2,6 +2,7 @@
   {
     "id": "encyclopedia_arcana",
     "type": "BOOK",
+    "category": "manuals",
     "looks_like": "textbook_chemistry",
     "name": { "str_sp": "Rebuilding Civilization: Arcana" },
     "description": "The clear work of a lunatic, the arcana volume of the Rebuilding Civilization encyclopedia.  Evidently not intended for mass distribution, instead printed in limited numbers for reference purposes.  This book contains everything from fundamental anomalous materials to the properties of dimensional fatigue in extremely fine detail.  Literally any other book on the subject would be a more efficient way to learn, but this may be a good substitute until you find something better.",


### PR DESCRIPTION
CDDA added the 'manual' category to skillbooks in [#53852](https://github.com/CleverRaven/Cataclysm-DDA/pull/53852#issue-1090194548) .  Adding this category to skillbooks in Arcana so there isn't a mismatch.