### PR TITLE
Pending BN update: new bionic itemgroup

### DIFF
--- a/Arcana_BN/item_groups/item_groups_vanilla.json
+++ b/Arcana_BN/item_groups/item_groups_vanilla.json
@@ -285,6 +285,16 @@
     ]
   },
   {
+    "id": "bionics_mil",
+    "type": "item_group",
+    "items": [ { "group": "lab_magitech_bionics", "prob": 5 } ]
+  },
+  {
+    "id": "bionics_heavy_mil",
+    "type": "item_group",
+    "items": [ [ "bio_essence_surge_cell", 1 ], [ "bio_temporal_stimulation", 1 ] ]
+  },
+  {
     "id": "bionics_op",
     "type": "item_group",
     "items": [ [ "bio_electrothermal_arc_projector", 1 ], [ "bio_rift_focus_projector", 1 ], [ "bio_temporal_stimulation", 2 ] ]


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3769 is merged, which adds a new bionic itemgroup for military stuff.

Additionally, belatedly added an itemgroup injection to `bionics_mil`.