### PR TITLE
Pending BN update: human_maybe_survivalist_bionics harvest entry

### DIFF
--- a/Arcana_BN/monsters/monsters.json
+++ b/Arcana_BN/monsters/monsters.json
@@ -1082,6 +1082,8 @@
     "armor_bullet": 9,
     "dodge": 2,
     "diff": 2,
+    "//": "Some of them may be feral arcane purifiers/operatives instead of conventional mage hunters.",
+    "harvest": "human_maybe_survivalist_bionics",
     "special_attacks": [
       [ "PARROT_AT_DANGER", 5 ],
       {


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3781 is merged. All it does is make use of the `human_maybe_survivalist_bionics` harvest entry for feral mage hunters, on the basis that some of them may have been urban contacts in the vein of arcane purifiers/operatives.