### PR TITLE
Pending BN feature: accessories with COMPACT flag

### DIFF
--- a/Arcana_BN/items/armor.json
+++ b/Arcana_BN/items/armor.json
@@ -310,6 +310,6 @@
       "draw_cost": 0,
       "flags": [ "MAGIC_FOCUS" ]
     },
-    "flags": [ "WAIST", "OVERSIZE" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE" ]
   }
 ]


### PR DESCRIPTION
Set aside as a draft for if https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3792 is merged. All it does is add `COMPACT` to satchel of eternity, as if it matters much given how much storage it has.