### PR TITLE
Pending BN Update: Bionic Infolink

### DIFF
--- a/Arcana_BN/chargen/professions.json
+++ b/Arcana_BN/chargen/professions.json
@@ -443,7 +443,7 @@
       "bio_flashlight",
       "bio_tools",
       "bio_batteries",
-      "bio_watch",
+      "bio_infolink",
       "bio_life_sign_suppression",
       "bio_power_storage_mkII"
     ],

--- a/Arcana_BN/npcs/NC_FILES.json
+++ b/Arcana_BN/npcs/NC_FILES.json
@@ -199,6 +199,7 @@
       { "id": "bio_metabolics", "chance": 25 },
       { "id": "bio_power_storage_mkII", "chance": 100 },
       { "id": "bio_targeting", "chance": 50 },
+      { "id": "bio_infolink", "chance": 50 },
       { "id": "bio_tools", "chance": 75 }
     ],
     "worn_override": "NC_CF_PURIFIER_worn",


### PR DESCRIPTION
Simple lil thing set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4106 is merged, only change that ended up being needed for now is giving arcane purifier profession the new infolink CBM instead of bionic watch, and making it so the purifier NPCs can potentially have them due to it having been made NPC installable.