### PR TITLE
Pending BN Update: Take Cover!

### DIFF
--- a/Arcana/furniture_and_terrain/furniture.json
+++ b/Arcana/furniture_and_terrain/furniture.json
@@ -28,7 +28,8 @@
     "crafting_pseudo_item": "candle_warding_active",
     "flags": [ "TRANSPARENT", "USABLE_FIRE" ],
     "deployed_item": "candle_barrier_aftermath",
-    "examine_action": "deployed_furniture"
+    "examine_action": "deployed_furniture",
+    "bash": { "str_min": 500, "str_max": 2500, "sound": "crash!", "sound_fail": "whump." }
   },
   {
     "id": "f_candle_barrier_playermade",
@@ -46,8 +47,8 @@
     "deployed_item": "candle_warding",
     "examine_action": "deployed_furniture",
     "bash": {
-      "str_min": 40,
-      "str_max": 210,
+      "str_min": 50,
+      "str_max": 250,
       "sound": "crash!",
       "sound_fail": "whump.",
       "items": [ { "item": "candle_warding", "count": [ 0, 1 ] } ]
@@ -62,6 +63,7 @@
     "description": "A structure of flowing, living stone molded into an open fireplace, the surface cracking and reforming periodically.  It offers modest space to burn offerings safely, or a flat surface sufficient for more morbid rituals.",
     "color": "dark_gray",
     "move_cost_mod": 2,
+    "coverage": 60,
     "required_str": -1,
     "crafting_pseudo_item": "boulder_anvil",
     "flags": [
@@ -76,7 +78,7 @@
       "MINEABLE",
       "FLAT_SURF"
     ],
-    "bash": { "str_min": 10, "str_max": 20, "sound": "smash!", "sound_fail": "thump." },
+    "bash": { "str_min": 20, "str_max": 40, "sound": "smash!", "sound_fail": "thump." },
     "examine_action": "fireplace"
   },
   {
@@ -92,7 +94,7 @@
     "move_cost_mod": 0,
     "required_str": -1,
     "flags": [ "FLAMMABLE_HARD", "TRANSPARENT", "INDOORS", "SUN_ROOF_ABOVE", "NOCOLLIDE" ],
-    "bash": { "str_min": 5, "str_max": 30, "sound": "smash!", "sound_fail": "whump." }
+    "bash": { "str_min": 15, "str_max": 30, "sound": "smash!", "sound_fail": "whump." }
   },
   {
     "type": "furniture",
@@ -105,7 +107,7 @@
     "move_cost_mod": -1,
     "required_str": -1,
     "flags": [ "NOITEM", "BLOCK_WIND", "SUN_ROOF_ABOVE" ],
-    "bash": { "str_min": 20, "str_max": 60, "sound": "crash!", "sound_fail": "thump!" }
+    "bash": { "str_min": 30, "str_max": 60, "sound": "crash!", "sound_fail": "thump!" }
   },
   {
     "type": "furniture",
@@ -119,7 +121,7 @@
     "required_str": -1,
     "flags": [ "DOOR", "FLAMMABLE_HARD", "NOITEM", "BLOCK_WIND", "SUN_ROOF_ABOVE" ],
     "open": "f_door_arcana_o",
-    "bash": { "str_min": 4, "str_max": 40, "sound": "smash!", "sound_fail": "whump!" }
+    "bash": { "str_min": 20, "str_max": 40, "sound": "smash!", "sound_fail": "whump!" }
   },
   {
     "type": "furniture",
@@ -133,7 +135,7 @@
     "required_str": -1,
     "flags": [ "FLAMMABLE_HARD", "TRANSPARENT", "INDOORS", "SUN_ROOF_ABOVE" ],
     "close": "f_door_arcana_c",
-    "bash": { "str_min": 4, "str_max": 40, "sound": "smash!", "sound_fail": "whump!" }
+    "bash": { "str_min": 20, "str_max": 40, "sound": "smash!", "sound_fail": "whump!" }
   },
   {
     "type": "furniture",
@@ -216,7 +218,7 @@
     "color": "dark_gray",
     "looks_like": "f_slab",
     "move_cost_mod": 2,
-    "coverage": 30,
+    "coverage": 50,
     "required_str": 12,
     "crafting_pseudo_item": "transmutation_crucible_deployed_fake",
     "flags": [ "PLACE_ITEM", "BLOCKSDOOR", "TRANSPARENT", "ALLOW_FIELD_EFFECT", "MOUNTABLE", "SHORT", "MINEABLE", "FLAT_SURF" ],

--- a/Arcana_BN/furniture_and_terrain/furniture.json
+++ b/Arcana_BN/furniture_and_terrain/furniture.json
@@ -28,7 +28,8 @@
     "crafting_pseudo_item": "candle_warding_active",
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "USABLE_FIRE" ],
     "deployed_item": "candle_barrier_aftermath",
-    "examine_action": "deployed_furniture"
+    "examine_action": "deployed_furniture",
+    "bash": { "str_min": 500, "str_max": 2500, "sound": "crash!", "sound_fail": "whump.", "ranged": { "reduction": [ 500, 500 ] } }
   },
   {
     "id": "f_candle_barrier_playermade",
@@ -46,11 +47,12 @@
     "deployed_item": "candle_warding",
     "examine_action": "deployed_furniture",
     "bash": {
-      "str_min": 40,
-      "str_max": 210,
+      "str_min": 50,
+      "str_max": 250,
       "sound": "crash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "candle_warding", "count": [ 0, 1 ] } ]
+      "items": [ { "item": "candle_warding", "count": [ 0, 1 ] } ],
+      "ranged": { "reduction": [ 50, 50 ] }
     }
   },
   {
@@ -62,6 +64,7 @@
     "description": "A structure of flowing, living stone molded into an open fireplace, the surface cracking and reforming periodically.  It offers modest space to burn offerings safely, or a flat surface sufficient for more morbid rituals.",
     "color": "dark_gray",
     "move_cost_mod": 2,
+    "coverage": 60,
     "required_str": -1,
     "crafting_pseudo_item": "boulder_anvil",
     "flags": [
@@ -76,7 +79,13 @@
       "MINEABLE",
       "FLAT_SURF"
     ],
-    "bash": { "str_min": 10, "str_max": 20, "sound": "smash!", "sound_fail": "thump." },
+    "bash": {
+      "str_min": 20,
+      "str_max": 40,
+      "sound": "smash!",
+      "sound_fail": "thump.",
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+    },
     "examine_action": "fireplace"
   },
   {
@@ -92,7 +101,7 @@
     "move_cost_mod": 0,
     "required_str": -1,
     "flags": [ "FLAMMABLE_HARD", "TRANSPARENT", "INDOORS", "SUN_ROOF_ABOVE", "NOCOLLIDE" ],
-    "bash": { "str_min": 5, "str_max": 30, "sound": "smash!", "sound_fail": "whump." }
+    "bash": { "str_min": 15, "str_max": 30, "sound": "smash!", "sound_fail": "whump." }
   },
   {
     "type": "furniture",
@@ -105,7 +114,13 @@
     "move_cost_mod": -1,
     "required_str": -1,
     "flags": [ "NOITEM", "BLOCK_WIND", "SUN_ROOF_ABOVE" ],
-    "bash": { "str_min": 20, "str_max": 60, "sound": "crash!", "sound_fail": "thump!" }
+    "bash": {
+      "str_min": 30,
+      "str_max": 60,
+      "sound": "crash!",
+      "sound_fail": "thump!",
+      "ranged": { "reduction": [ 30, 60 ], "destroy_threshold": 60 }
+    }
   },
   {
     "type": "furniture",
@@ -119,7 +134,13 @@
     "required_str": -1,
     "flags": [ "DOOR", "FLAMMABLE_HARD", "NOITEM", "BLOCK_WIND", "SUN_ROOF_ABOVE" ],
     "open": "f_door_arcana_o",
-    "bash": { "str_min": 4, "str_max": 40, "sound": "smash!", "sound_fail": "whump!" }
+    "bash": {
+      "str_min": 20,
+      "str_max": 40,
+      "sound": "smash!",
+      "sound_fail": "whump!",
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 40 }
+    }
   },
   {
     "type": "furniture",
@@ -133,7 +154,7 @@
     "required_str": -1,
     "flags": [ "FLAMMABLE_HARD", "TRANSPARENT", "INDOORS", "SUN_ROOF_ABOVE" ],
     "close": "f_door_arcana_c",
-    "bash": { "str_min": 4, "str_max": 40, "sound": "smash!", "sound_fail": "whump!" }
+    "bash": { "str_min": 20, "str_max": 40, "sound": "smash!", "sound_fail": "whump!" }
   },
   {
     "type": "furniture",
@@ -152,7 +173,8 @@
       "str_max": 400,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "items": [ { "item": "rock", "count": [ 2, 5 ] } ]
+      "items": [ { "item": "rock", "count": [ 2, 5 ] } ],
+      "ranged": { "reduction": [ 100, 200 ], "destroy_threshold": 200, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -173,7 +195,8 @@
       "str_max": 400,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "items": [ { "item": "rock", "count": [ 2, 5 ] } ]
+      "items": [ { "item": "rock", "count": [ 2, 5 ] } ],
+      "ranged": { "reduction": [ 100, 200 ], "destroy_threshold": 200, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -190,7 +213,7 @@
     "flags": [ "NOITEM", "TRANSPARENT" ],
     "deployed_item": "candle_barrier_aftermath",
     "examine_action": "deployed_furniture",
-    "bash": { "str_min": 100, "str_max": 400, "sound": "crash!", "sound_fail": "whump!" }
+    "bash": { "str_min": 100, "str_max": 500, "sound": "crash!", "sound_fail": "whump!", "ranged": { "reduction": [ 50, 50 ] } }
   },
   {
     "type": "furniture",
@@ -216,7 +239,7 @@
     "color": "dark_gray",
     "looks_like": "f_slab",
     "move_cost_mod": 2,
-    "coverage": 30,
+    "coverage": 50,
     "required_str": 12,
     "crafting_pseudo_item": "transmutation_crucible_deployed_fake",
     "flags": [ "PLACE_ITEM", "BLOCKSDOOR", "TRANSPARENT", "ALLOW_FIELD_EFFECT", "MOUNTABLE", "SHORT", "MINEABLE", "FLAT_SURF" ],
@@ -226,7 +249,8 @@
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "thump.",
-      "items": [ { "item": "transmutation_crucible", "prob": 75 }, { "item": "rock", "count": [ 2, 7 ] } ]
+      "items": [ { "item": "transmutation_crucible", "prob": 75 }, { "item": "rock", "count": [ 2, 7 ] } ],
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     },
     "examine_action": "workbench",
     "workbench": { "multiplier": 1.05, "mass": 500000, "volume": "500L" }


### PR DESCRIPTION
Simple lil self-PR set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4129 is merged. Applies the newly-available damage resistance feature to fitting furniture items in the mod. Which means now candle barriers actually work as barriers. :>