### PR TITLE
"time" changed to math.

### DIFF
--- a/Arcana/spells/effect_on_condition.json
+++ b/Arcana/spells/effect_on_condition.json
@@ -11,8 +11,8 @@
       ]
     },
     "effect": [
-      { "arithmetic": [ { "global_val": "var", "var_name": "ps_min_length" }, "=", { "time": "2 hours" } ] },
-      { "arithmetic": [ { "global_val": "var", "var_name": "ps_max_length" }, "=", { "time": "4 hours" } ] },
+      { "math": [ "ps_min_length", "=", "time('2 hours')" ] },
+      { "math": [ "ps_max_length", "=", "time('4 hours')" ] },
       { "arithmetic": [ { "global_val": "var", "var_name": "ps_base_str" }, "=", { "const": 1 } ] },
       { "arithmetic": [ { "global_val": "var", "var_name": "cause_portal_storm" }, "=", { "const": 1 } ] },
       { "arithmetic": [ { "global_val": "var", "var_name": "cause_early_portal_storm" }, "=", { "const": 0 } ] },


### PR DESCRIPTION
Some time stuff is now handled with math since https://github.com/CleverRaven/Cataclysm-DDA/pull/70996.
Beware, there are a lot more changes like this coming soon, I'm afraid.
Like here: https://github.com/CleverRaven/Cataclysm-DDA/pull/71216
Don't like how CleverRaven gets mentions on their end, because of links, is there any way to stop that?
It seems it's too late to change the mentions now, *sigh*.