### PR TITLE
Pending BN Update: Nether Updates

### DIFF
--- a/Arcana_BN/monsters/monster_drops.json
+++ b/Arcana_BN/monsters/monster_drops.json
@@ -656,6 +656,7 @@
     "type": "item_group",
     "id": "mon_gozu_death_drops",
     "subtype": "collection",
+    "//": "Adds to existing group",
     "entries": [ { "item": "gracken_knuckles", "prob": 45 }, { "item": "essence", "prob": 50, "count": [ 1, 3 ] } ]
   },
   {
@@ -1492,8 +1493,12 @@
     "type": "item_group",
     "id": "mon_bound_glyph_death_drops_universal",
     "subtype": "collection",
-    "entries": [
-      { "item": "silver_glyph" }
-    ]
+    "entries": [ { "item": "silver_glyph" } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_mothman_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "shadow_gem" }, { "item": "essence", "count": [ 1, 3 ] } ]
   }
 ]

--- a/Arcana_BN/monsters/monster_factions.json
+++ b/Arcana_BN/monsters/monster_factions.json
@@ -12,7 +12,8 @@
   {
     "type": "MONSTER_FACTION",
     "name": "nether",
-    "friendly": [ "slime", "cult", "moruboru", "archon" ]
+    "friendly": [ "slime", "cult", "moruboru", "archon" ],
+    "neutral": [ "zombie", "zombie_aquatic", "science" ]
   },
   {
     "type": "MONSTER_FACTION",

--- a/Arcana_BN/monsters/monster_overrides.json
+++ b/Arcana_BN/monsters/monster_overrides.json
@@ -462,7 +462,6 @@
     "id": "mon_gozu",
     "copy-from": "mon_gozu",
     "type": "MONSTER",
-    "death_drops": "mon_gozu_death_drops",
     "extend": { "categories": [ "CLASSIC" ] }
   },
   {
@@ -764,5 +763,12 @@
     "copy-from": "mon_zombie_soldier_acid_2",
     "type": "MONSTER",
     "death_drops": "mon_zombie_soldier_acid_2_death_drops"
+  },
+  {
+    "id": "mon_mothman",
+    "copy-from": "mon_mothman",
+    "type": "MONSTER",
+    "death_drops": "mon_mothman_death_drops",
+    "extend": { "categories": [ "CLASSIC" ] }
   }
 ]

--- a/Arcana_BN/monsters/monsters.json
+++ b/Arcana_BN/monsters/monsters.json
@@ -490,7 +490,7 @@
     "death_drops": "mon_bound_glyph_death_drops_universal",
     "revert_to_itype": "summon_yugg_bound",
     "extend": { "flags": [ "PATH_AVOID_DANGER_2", "PRIORITIZE_TARGETS", "PET_MOUNTABLE" ] },
-    "delete": { "flags": [ "BASHES", "DESTROYS", "DIGS" ] }
+    "delete": { "flags": [ "BASHES", "CAN_DIG" ] }
   },
   {
     "id": "mon_kreck_summoned",


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4182 is merged.

1. Added death drop override for lepidopterid, currently same as wraiths.
2. No longer have to inject death drop itemgroup into gozu since it gains vanilla death drops the items are now being added to.
3. Updated override for nether faction to preserve the added neutrality with zeds.
4. Update flag changes for summoned yuggs.