### PR TITLE
Pending BN update: `CAN_BE_ORDERED` monster flag

### DIFF
--- a/Arcana_BN/monsters/monsters.json
+++ b/Arcana_BN/monsters/monsters.json
@@ -489,7 +489,7 @@
     "death_function": [ "MELT" ],
     "death_drops": "mon_bound_glyph_death_drops_universal",
     "revert_to_itype": "summon_yugg_bound",
-    "extend": { "flags": [ "PATH_AVOID_DANGER_2", "PRIORITIZE_TARGETS", "PET_MOUNTABLE" ] },
+    "extend": { "flags": [ "PATH_AVOID_DANGER_2", "PRIORITIZE_TARGETS", "PET_MOUNTABLE", "CAN_BE_ORDERED" ] },
     "delete": { "flags": [ "BASHES", "CAN_DIG" ] }
   },
   {
@@ -536,7 +536,7 @@
         "monster_message": "The summoned triffid fires a dart at %3$s!"
       }
     ],
-    "extend": { "flags": [ "VENOM", "PATH_AVOID_DANGER_2", "PRIORITIZE_TARGETS", "PET_HARNESSABLE" ] },
+    "extend": { "flags": [ "VENOM", "PATH_AVOID_DANGER_2", "PRIORITIZE_TARGETS", "PET_HARNESSABLE", "CAN_BE_ORDERED" ] },
     "delete": { "flags": [ "BASHES", "GROUP_BASH" ] }
   },
   {
@@ -583,7 +583,7 @@
     "armor_bullet": 10,
     "death_drops": "mon_bound_glyph_death_drops_universal",
     "revert_to_itype": "summon_hunting_horror_bound",
-    "extend": { "flags": [ "PATH_AVOID_DANGER_2", "PRIORITIZE_TARGETS", "ELECTRIC", "PET_HARNESSABLE" ] },
+    "extend": { "flags": [ "PATH_AVOID_DANGER_2", "PRIORITIZE_TARGETS", "ELECTRIC", "PET_HARNESSABLE", "CAN_BE_ORDERED" ] },
     "delete": { "flags": [ "SUNDEATH", "HIT_AND_RUN" ] }
   },
   {
@@ -601,7 +601,7 @@
     "special_attacks": [ { "id": "scratch", "damage_max_instance": [ { "damage_type": "cut", "amount": 23, "armor_multiplier": 0.8 } ] } ],
     "death_drops": "mon_bound_glyph_death_drops_universal",
     "revert_to_itype": "summon_mi_go_bound",
-    "extend": { "flags": [ "PET_HARNESSABLE" ] },
+    "extend": { "flags": [ "PET_HARNESSABLE", "CAN_BE_ORDERED" ] },
     "delete": { "flags": [ "BASHES" ] }
   },
   {
@@ -620,7 +620,7 @@
     "death_drops": "mon_bound_glyph_death_drops_universal",
     "revert_to_itype": "summon_flying_polyp_bound",
     "special_attacks": [ { "type": "bite", "cooldown": 20, "damage_max_instance": [ { "damage_type": "cold", "amount": 20 } ] } ],
-    "extend": { "flags": [ "SEES", "PATH_AVOID_DANGER_2", "PRIORITIZE_TARGETS", "PET_HARNESSABLE" ] },
+    "extend": { "flags": [ "SEES", "PATH_AVOID_DANGER_2", "PRIORITIZE_TARGETS", "PET_HARNESSABLE", "CAN_BE_ORDERED" ] },
     "delete": { "flags": [ "BASHES", "ATTACKMON" ] }
   },
   {
@@ -638,7 +638,7 @@
     "regeneration_modifiers": [ { "effect": "dazed", "base_mod": -1.0 } ],
     "death_drops": "mon_bound_glyph_death_drops_universal",
     "revert_to_itype": "summon_shoggoth_bound",
-    "extend": { "flags": [ "PATH_AVOID_DANGER_2", "PRIORITIZE_TARGETS", "PET_HARNESSABLE" ] },
+    "extend": { "flags": [ "PATH_AVOID_DANGER_2", "PRIORITIZE_TARGETS", "PET_HARNESSABLE", "CAN_BE_ORDERED" ] },
     "delete": { "flags": [ "ABSORBS_SPLITS" ] },
     "special_attacks": [ { "id": "slam", "cooldown": 25, "damage_max_instance": [ { "damage_type": "acid", "amount": 35 } ] } ]
   },
@@ -1203,7 +1203,8 @@
     "type": "MONSTER",
     "name": { "str": "summoned kreck" },
     "death_drops": "mon_bound_glyph_death_drops_universal",
-    "revert_to_itype": "summon_kreck_bound"
+    "revert_to_itype": "summon_kreck_bound",
+    "extend": { "flags": [ "CAN_BE_ORDERED" ] }
   },
   {
     "id": "mon_flesh_angel_summoned_glyph",
@@ -1211,7 +1212,8 @@
     "type": "MONSTER",
     "name": { "str": "summoned flesh angel" },
     "death_drops": "mon_bound_glyph_death_drops_universal",
-    "revert_to_itype": "summon_flesh_angel_bound"
+    "revert_to_itype": "summon_flesh_angel_bound",
+    "extend": { "flags": [ "CAN_BE_ORDERED" ] }
   },
   {
     "id": "mon_dark_wyrm_summoned_glyph",
@@ -1219,7 +1221,8 @@
     "type": "MONSTER",
     "name": { "str": "summoned dark wyrm" },
     "death_drops": "mon_bound_glyph_death_drops_universal",
-    "revert_to_itype": "summon_dark_wyrm_bound"
+    "revert_to_itype": "summon_dark_wyrm_bound",
+    "extend": { "flags": [ "CAN_BE_ORDERED" ] }
   },
   {
     "id": "mon_jabberwock_summoned_glyph",
@@ -1227,6 +1230,7 @@
     "type": "MONSTER",
     "name": { "str": "summoned jabberwock" },
     "death_drops": "mon_bound_glyph_death_drops_universal",
-    "revert_to_itype": "summon_jabberwock_bound"
+    "revert_to_itype": "summon_jabberwock_bound",
+    "extend": { "flags": [ "CAN_BE_ORDERED" ] }
   }
 ]


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4247 is merged, applies the new monster flag to glyph summons so they can all be marked as docile if desired.