### PR TITLE
Update palette ID

### DIFF
--- a/Arcana/overmap_and_mapgen/mapgen_variants.json
+++ b/Arcana/overmap_and_mapgen/mapgen_variants.json
@@ -2310,7 +2310,7 @@
         ".....4..................",
         "........................"
       ],
-      "palettes": [ "standard_building_palette", "library_palette" ],
+      "palettes": [ "standard_building_shared_palette", "library_palette" ],
       "terrain": { "x": "t_door_locked_interior" },
       "place_loot": [
         { "item": "matches", "x": 3, "y": 12, "chance": 50 },
@@ -2369,7 +2369,7 @@
         ".5.....5..#[[[y: | [#...",
         "..........######o####..."
       ],
-      "palettes": [ "standard_building_palette", "library_palette" ],
+      "palettes": [ "standard_building_shared_palette", "library_palette" ],
       "terrain": { "x": "t_door_locked_interior" },
       "place_loot": [
         { "item": "matches", "x": 11, "y": 18, "chance": 50 },
@@ -2429,7 +2429,7 @@
         "...........#X |C  + t#..",
         "...........###########.."
       ],
-      "palettes": [ "standard_building_palette", "library_palette" ],
+      "palettes": [ "standard_building_shared_palette", "library_palette" ],
       "nested": { "G": { "chunks": [ "roof_6x6_garden_1" ] } },
       "terrain": { "G": "t_grass", "x": "t_door_locked_interior" },
       "furniture": { "X": "f_safe_l" },


### PR DESCRIPTION
https://github.com/CleverRaven/Cataclysm-DDA/pull/72164 changed the palette ID to another one.

It also added another id to enable vandalized variants but in the name of keeping functionality the same I used the one with the same current function.