### PR TITLE
Changes to match upstream updates

### DIFF
--- a/Arcana/monsters/monstergroups.json
+++ b/Arcana/monsters/monstergroups.json
@@ -180,7 +180,7 @@
     "monsters": [ { "monster": "mon_fleshy_shambler", "weight": 25, "cost_multiplier": 10 } ]
   },
   {
-    "name": "GROUP_MANSION",
+    "name": "GROUP_MANSION_START",
     "type": "monstergroup",
     "override": false,
     "auto_total": true,

--- a/Arcana/mutations/mutations_dragonblood.json
+++ b/Arcana/mutations/mutations_dragonblood.json
@@ -274,7 +274,6 @@
     "points": 1,
     "mixed_effect": true,
     "bodytemp_modifiers": [ 125, 500 ],
-    "bodytemp_sleep": 125,
     "description": "A strange heat permeates your body, warming you up in exchange for a more active metabolism.  While you need to eat and drink more, you also find it easier to recover from physical exertion and mend wounds.",
     "valid": false,
     "purifiable": false,
@@ -287,13 +286,14 @@
           { "value": "METABOLISM", "multiply": 0.25 },
           { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 0.5 },
           { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 0.125 },
-          { "value": "STAMINA_REGEN_MOD", "add": 0.5 }
+          { "value": "STAMINA_REGEN_MOD", "add": 0.5 },
+          { "value": "BODYTEMP_SLEEP", "add": 0.25 },
+          { "value": "REGEN_HP_AWAKE", "multiply": 0.5 },
+          { "value": "REGEN_HP", "multiply": 0.25 },
+          { "value": "MENDING_MODIFIER", "multiply": -0.5 }
         ]
       }
     ],
-    "healing_awake": 0.5,
-    "healing_multiplier": 1.25,
-    "mending_modifier": 0.5,
     "vitamin_rates": [ [ "blood", -5 ], [ "redcells", -5 ] ],
     "flags": [ "PRED1" ]
   },
@@ -304,7 +304,6 @@
     "points": 2,
     "mixed_effect": true,
     "bodytemp_modifiers": [ 250, 1000 ],
-    "bodytemp_sleep": 250,
     "description": "That strange warmth deep within your body has grown more intense, and its effects have become more pronounced.  While you still need to eat and drink more, your stamina and healing have adapted in turn.  A strange glow can also be faintly seen in the back of your throat, lending an unnatural aura of menace to your every word.",
     "valid": false,
     "purifiable": false,
@@ -319,13 +318,14 @@
           { "value": "METABOLISM", "multiply": 0.5 },
           { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 1.0 },
           { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 0.25 },
-          { "value": "STAMINA_REGEN_MOD", "add": 0.666 }
+          { "value": "STAMINA_REGEN_MOD", "add": 0.666 },
+          { "value": "BODYTEMP_SLEEP", "add": 0.5 },
+          { "value": "REGEN_HP_AWAKE", "multiply": 1.0 },
+          { "value": "REGEN_HP", "multiply": 0.5 },
+          { "value": "MENDING_MODIFIER", "multiply": 0.0 }
         ]
       }
     ],
-    "healing_awake": 1.0,
-    "healing_multiplier": 1.5,
-    "mending_modifier": 1.0,
     "social_modifiers": { "persuade": -25, "intimidate": 25 },
     "vitamin_rates": [ [ "blood", -3 ], [ "redcells", -3 ] ],
     "flags": [ "PRED2" ]
@@ -337,7 +337,6 @@
     "points": 3,
     "mixed_effect": true,
     "bodytemp_modifiers": [ 0, 1500 ],
-    "bodytemp_sleep": 750,
     "description": "Your body has adapted further, exploiting the strange power that fuels your body.  You still need more food and water than normal, but the benefits are more pronounced relative to the drawbacks.  Activate to breathe short-ranged bursts of flame.",
     "valid": false,
     "purifiable": false,
@@ -352,13 +351,14 @@
           { "value": "METABOLISM", "multiply": 0.75 },
           { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 1.25 },
           { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 0.375 },
-          { "value": "STAMINA_REGEN_MOD", "add": 0.75 }
+          { "value": "STAMINA_REGEN_MOD", "add": 0.75 },
+          { "value": "BODYTEMP_SLEEP", "add": 1.5 },
+          { "value": "REGEN_HP_AWAKE", "multiply": 2.5 },
+          { "value": "REGEN_HP", "multiply": 1.25 },
+          { "value": "MENDING_MODIFIER", "multiply": 1.5 }
         ]
       }
     ],
-    "healing_awake": 2.5,
-    "healing_multiplier": 2.25,
-    "mending_modifier": 2.5,
     "social_modifiers": { "persuade": -25, "intimidate": 25 },
     "active": true,
     "cost": 500,

--- a/Arcana/mutations/mutations_other.json
+++ b/Arcana/mutations/mutations_other.json
@@ -430,11 +430,11 @@
         "condition": "ALWAYS",
         "values": [
           { "value": "ATTACK_SPEED", "multiply": -0.2 },
-          { "value": "BONUS_DODGE", "add": 3}
+          { "value": "BONUS_DODGE", "add": 3},
+          { "value": "MENDING_MODIFIER", "multiply": 2499 }
         ]
       }
     ],
-    "mending_modifier": 2500.0,
     "anger_relations": [
       [ "NETHER", 10 ],
       [ "SLIME", 10 ],

--- a/Arcana/overmap_and_mapgen/mapgen_variants.json
+++ b/Arcana/overmap_and_mapgen/mapgen_variants.json
@@ -47,7 +47,7 @@
         "r": { "item": "office", "chance": 35 },
         "t": { "item": "table_livingroom", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_MANSION", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_MANSION_START", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -104,7 +104,7 @@
         "t": { "item": "nightstand", "chance": 35 },
         "z": { "item": "dresser_stack", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_MANSION", "x": [ 4, 21 ], "y": [ 2, 9 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_MANSION_START", "x": [ 4, 21 ], "y": [ 2, 9 ], "density": 0.1 } ]
     }
   },
   {
@@ -157,7 +157,7 @@
         "t": { "item": "table_card", "chance": 35 },
         "{": { "item": "suit_of_armor", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_MANSION", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_MANSION_START", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -204,7 +204,7 @@
         "d": { "item": "mansion_guns", "chance": 100 },
         "l": { "item": "mansion_bookcase", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_MANSION", "x": [ 15, 21 ], "y": [ 9, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_MANSION_START", "x": [ 15, 21 ], "y": [ 9, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -266,7 +266,7 @@
         { "group": "mansion_gunsafe", "x": 14, "y": 12, "chance": 100 },
         { "group": "sanguine_cult_consumables", "x": 14, "y": 12, "chance": 50, "repeat": 3 }
       ],
-      "place_monsters": [ { "monster": "GROUP_MANSION", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ],
+      "place_monsters": [ { "monster": "GROUP_MANSION_START", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ],
       "place_monster": [ { "monster": "mon_gozu", "x": 11, "y": 11 } ]
     }
   },
@@ -324,7 +324,7 @@
         { "group": "antique_rare", "x": 4, "y": [ 16, 18 ], "chance": 50, "repeat": 4 },
         { "group": "chalice_cult_consumables", "x": 8, "y": [ 16, 18 ], "chance": 50, "repeat": 4 }
       ],
-      "place_monsters": [ { "monster": "GROUP_MANSION", "x": [ 2, 21 ], "y": [ 2, 8 ], "density": 0.1 } ],
+      "place_monsters": [ { "monster": "GROUP_MANSION_START", "x": [ 2, 21 ], "y": [ 2, 8 ], "density": 0.1 } ],
       "place_monster": [ { "monster": "mon_vortex", "x": [ 5, 7 ], "y": [ 11, 18 ], "repeat": [ 2, 4 ] } ]
     }
   },


### PR DESCRIPTION
Some more stuff moved to enchantments. Not sure if the new MENDING_MODIFIER values are set correctly though. GROUP_MANSION was removed and replaced with GROUP_MANSION_START which is only used for mansion starts, if that's how you'd like it then the changes should work as is, if not that'll need changing as well.