### PR TITLE
[DDA] Convert martial arts technique attack_vectors to new format

### DIFF
--- a/Arcana/techniques.json
+++ b/Arcana/techniques.json
@@ -13,7 +13,7 @@
     "weighting": 3,
     "down_dur": 2,
     "mult_bonuses": [ { "stat": "movecost", "scale": 0.8 } ],
-    "attack_vectors": [ "WEAPON" ]
+    "attack_vectors": [ "vector_null" ]
   },
   {
     "type": "technique",
@@ -32,7 +32,7 @@
     "weighting": 3,
     "stun_dur": 2,
     "mult_bonuses": [ { "stat": "movecost", "scale": 0.8 } ],
-    "attack_vectors": [ "WEAPON" ]
+    "attack_vectors": [ "vector_null" ]
   },
   {
     "type": "technique",
@@ -47,7 +47,7 @@
     "stun_dur": 1,
     "disarms": true,
     "mult_bonuses": [ { "stat": "movecost", "scale": 0.8 } ],
-    "attack_vectors": [ "WEAPON" ]
+    "attack_vectors": [ "vector_null" ]
   },
   {
     "type": "technique",
@@ -73,7 +73,7 @@
     "stun_dur": 2,
     "flat_bonuses": [ { "stat": "arpen", "type": "bash", "scale": 5 } ],
     "mult_bonuses": [ { "stat": "movecost", "scale": 0.0 } ],
-    "attack_vectors": [ "WEAPON" ]
+    "attack_vectors": [ "vector_null" ]
   },
   {
     "type": "technique",
@@ -88,7 +88,7 @@
     "stun_dur": 2,
     "flat_bonuses": [ { "stat": "arpen", "type": "cut", "scale": 5 } ],
     "mult_bonuses": [ { "stat": "movecost", "scale": 0.0 } ],
-    "attack_vectors": [ "WEAPON" ]
+    "attack_vectors": [ "vector_null" ]
   },
   {
     "type": "technique",
@@ -103,7 +103,7 @@
     "down_dur": 2,
     "flat_bonuses": [ { "stat": "arpen", "type": "bash", "scale": 5 } ],
     "mult_bonuses": [ { "stat": "movecost", "scale": 0.0 } ],
-    "attack_vectors": [ "THROW" ]
+    "attack_vectors": [ "vector_grasp" ]
   },
   {
     "type": "technique",
@@ -116,7 +116,7 @@
     "required_buffs_all": [ "buff_shrike_onattack1" ],
     "crit_tec": true,
     "stun_dur": 2,
-    "attack_vectors": [ "WEAPON", "HAND" ]
+    "attack_vectors": [ "vector_null", "vector_punch" ]
   },
   {
     "type": "technique",
@@ -131,7 +131,7 @@
     "down_dur": 2,
     "stun_dur": 2,
     "mult_bonuses": [ { "stat": "movecost", "scale": 0.0 } ],
-    "attack_vectors": [ "WEAPON", "HAND" ]
+    "attack_vectors": [ "vector_null", "vector_punch" ]
   },
   {
     "type": "technique",
@@ -151,7 +151,7 @@
       { "stat": "arpen", "type": "stab", "scaling-stat": "dex", "scale": 1.0 }
     ],
     "mult_bonuses": [ { "stat": "damage", "type": "cut", "scale": 1.5 }, { "stat": "damage", "type": "stab", "scale": 1.5 } ],
-    "attack_vectors": [ "WEAPON", "HAND" ]
+    "attack_vectors": [ "vector_null", "vector_punch" ]
   },
   {
     "type": "technique",
@@ -178,7 +178,7 @@
     "weighting": -25,
     "messages": [ "Your blade sears through %s with a brilliant glow", "<npcname>'s blade sears through %s with a brilliant glow" ],
     "description": "+30 fire damage, crit only",
-    "attack_vectors": [ "WEAPON" ]
+    "attack_vectors": [ "vector_null" ]
   },
   {
     "type": "technique",
@@ -191,7 +191,7 @@
     "weighting": -30,
     "messages": [ "The runes on your blade shimmer as you hack into %s", "<npcname>'s blade shimmers as they hack into %s" ],
     "description": "+40 cold damage, crit only",
-    "attack_vectors": [ "WEAPON" ]
+    "attack_vectors": [ "vector_null" ]
   },
   {
     "type": "technique",
@@ -209,7 +209,7 @@
     "weighting": 2,
     "messages": [ "Your impact blasts %s back", "<npcname> blasts %s back" ],
     "description": "+0.5 bash damage and armor penetration per point of strength, down 1 turn, knockback 3 tiles, crit only",
-    "attack_vectors": [ "WEAPON" ]
+    "attack_vectors": [ "vector_null" ]
   },
   {
     "type": "technique",
@@ -226,7 +226,7 @@
     "weighting": -10,
     "stun_dur": 2,
     "messages": [ "Your strike resonates through %s", "<npcname>'s strike resonates through %s" ],
-    "attack_vectors": [ "WEAPON" ]
+    "attack_vectors": [ "vector_null" ]
   },
   {
     "type": "technique",
@@ -244,6 +244,6 @@
     "weighting": 2,
     "down_dur": 2,
     "messages": [ "Your blade flickers and sunders through %s", "<npcname>'s blade flickers and sunders through %s" ],
-    "attack_vectors": [ "WEAPON" ]
+    "attack_vectors": [ "vector_null" ]
   }
 ]


### PR DESCRIPTION
In https://github.com/CleverRaven/Cataclysm-DDA/pull/73064 the format for attack_vector definitions changed to allow for extra specificity/unhardcoding/etc.  This PR converts the old attack vector definitions to the new ones based on the linked PR's example with the DDA techniques.

Note: The current attack_vector definitions do not throw a startup error but will fail when actually trying to use them.