### PR TITLE
Pending BN Update: `ALLOWS_REMOTE_USE` works on more stuff

### DIFF
--- a/Arcana_BN/items/tools.json
+++ b/Arcana_BN/items/tools.json
@@ -552,7 +552,7 @@
       "is_pet": true,
       "skills": [ "magic" ]
     },
-    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT" ]
+    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT", "ALLOWS_REMOTE_USE" ]
   },
   {
     "id": "summon_blank",
@@ -574,7 +574,7 @@
       "is_pet": true,
       "skills": [ "magic" ]
     },
-    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT" ]
+    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT", "ALLOWS_REMOTE_USE" ]
   },
   {
     "id": "summon_flaming_eye",
@@ -596,7 +596,7 @@
       "is_pet": true,
       "skills": [ "magic" ]
     },
-    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT" ]
+    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT", "ALLOWS_REMOTE_USE" ]
   },
   {
     "id": "summon_hunting_horror",
@@ -618,7 +618,7 @@
       "is_pet": true,
       "skills": [ "magic" ]
     },
-    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT" ]
+    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT", "ALLOWS_REMOTE_USE" ]
   },
   {
     "id": "summon_dark_wyrm",
@@ -640,7 +640,7 @@
       "is_pet": true,
       "skills": [ "magic" ]
     },
-    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT" ]
+    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT", "ALLOWS_REMOTE_USE" ]
   },
   {
     "id": "summon_mi_go",
@@ -662,7 +662,7 @@
       "is_pet": true,
       "skills": [ "magic" ]
     },
-    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT" ]
+    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT", "ALLOWS_REMOTE_USE" ]
   },
   {
     "id": "summon_jabberwock",
@@ -683,7 +683,7 @@
       "is_pet": true,
       "skills": [ "magic" ]
     },
-    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT" ]
+    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT", "ALLOWS_REMOTE_USE" ]
   },
   {
     "id": "summon_flying_polyp",
@@ -705,7 +705,7 @@
       "is_pet": true,
       "skills": [ "magic" ]
     },
-    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT" ]
+    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT", "ALLOWS_REMOTE_USE" ]
   },
   {
     "id": "summon_yugg",
@@ -727,7 +727,7 @@
       "is_pet": true,
       "skills": [ "magic" ]
     },
-    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT" ]
+    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT", "ALLOWS_REMOTE_USE" ]
   },
   {
     "id": "summon_shoggoth",
@@ -749,7 +749,7 @@
       "is_pet": true,
       "skills": [ "magic" ]
     },
-    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT" ]
+    "flags": [ "NO_SALVAGE", "ACT_ON_RANGED_HIT", "ALLOWS_REMOTE_USE" ]
   },
   {
     "id": "summon_kreck_bound",
@@ -1055,7 +1055,7 @@
       },
       { "type": "deploy_furn", "furn_type": "f_candle_barrier_playermade" }
     ],
-    "flags": [ "NO_SALVAGE" ]
+    "flags": [ "NO_SALVAGE", "ALLOWS_REMOTE_USE" ]
   },
   {
     "id": "candle_warding_active",
@@ -1081,7 +1081,7 @@
       { "type": "firestarter", "moves": 100 },
       { "type": "deploy_furn", "furn_type": "f_candle_barrier_playermade" }
     ],
-    "flags": [ "NO_SALVAGE", "LIGHT_12", "FIRESTARTER" ]
+    "flags": [ "NO_SALVAGE", "LIGHT_12", "FIRESTARTER", "ALLOWS_REMOTE_USE" ]
   },
   {
     "id": "transmutation_crucible",
@@ -1098,6 +1098,7 @@
     "symbol": ";",
     "color": "brown",
     "looks_like": "crucible",
+    "flags": [ "ALLOWS_REMOTE_USE" ]
     "use_action": { "type": "deploy_furn", "furn_type": "f_transmutation_crucible_deployed" }
   },
   {
@@ -1341,7 +1342,6 @@
     "name": { "str": "inactive anomaly recon mech" },
     "description": "A hulking, yet unnaturally light, mass of parts running off anomalous technology, with an exotic laser weapon and advanced defensive tools.  Use it to deploy and set up the mech for piloting.",
     "volume": "500 L",
-    "//": "1% of the weight you'd expect, to make it feasible to deploy because ALLOWS_REMOTE_USE doesn't work right for place_monster action.",
     "weight": "7500 g",
     "price_postapoc": "75 USD",
     "to_hit": -3,
@@ -1350,6 +1350,7 @@
     "symbol": ",",
     "color": "cyan",
     "looks_like": "broken_mech_recon",
+    "flags": [ "ALLOWS_REMOTE_USE" ]
     "use_action": {
       "type": "place_monster",
       "monster_id": "mon_mech_arcana",


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5186 is merged, adds `ALLOWS_REMOTE_USE` to relevant `deploy_furn` and `place_monster` items.