### PR TITLE
Pending BN Update: Change to `drugdealer` itemgroup

### DIFF
--- a/Arcana_BN/item_groups/item_groups_vanilla.json
+++ b/Arcana_BN/item_groups/item_groups_vanilla.json
@@ -216,6 +216,7 @@
   {
     "id": "drugdealer",
     "type": "item_group",
+    "subtype": "collection",
     "items": [ { "group": "magic_books_postapoc", "prob": 5 } ]
   },
   {

--- a/Arcana_BN/modinfo.json
+++ b/Arcana_BN/modinfo.json
@@ -5,7 +5,7 @@
     "name": "<color_cyan>Arcana and Magic Items</color>",
     "authors": [ "Chaosvolt" ],
     "description": "Adds a host of craftable magic items and spells, centered around the use of Arcana skill to research and exploit otherworldly monsters and anomalies.",
-    "version": "BN version, update 10/16/2024",
+    "version": "BN version, update 10/31/2024",
     "category": "content",
     "dependencies": [ "bn" ]
   }


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5635 is merged, fixes the injection of items into the `drugdealer` itemgroup since it's getting converted to a collection (which in Arcana gains a chance of arcanist books being run, assumed to be rare black-market deals with lost books).