### PR TITLE
Pending BN Feature: `SNIPPET_NEEDS_LITERACY` flag

### DIFF
--- a/Arcana_BN/items/books.json
+++ b/Arcana_BN/items/books.json
@@ -3,7 +3,13 @@
     "id": "book_magicfordummies",
     "type": "BOOK",
     "name": { "str": "Apprentice's Notes", "str_pl": "copies of Apprentice's Notes" },
-    "description": "A series of handwritten notes by a student of some esoteric order.  At first the subject seems to be simple religious rituals, but it soon delves into more …anomalous practices.\n\"In time, my eyes will be opened.  They called it The Gift, but all who draw breath can partake of it.  There is no innate talent, no quirk of bloodline, only discipline and patience…\"",
+    "description": "A series of handwritten notes by a student of some esoteric order.  At first the subject seems to be simple religious rituals, but it soon delves into more …anomalous practices.",
+    "snippet_category": [
+      {
+        "id": "book_magicfordummies_1",
+        "text": "A series of handwritten notes by a student of some esoteric order.  At first the subject seems to be simple religious rituals, but it soon delves into more …anomalous practices.\n\"In time, my eyes will be opened.  They called it The Gift, but all who draw breath can partake of it.  There is no innate talent, no quirk of bloodline, only discipline and patience…\""
+      }
+    ],
     "weight": "454 g",
     "volume": "500 ml",
     "//": "Pre-apocalypse price is estimated by maximum arcana skill the book can reach, post-apoc price is a depreciation derived from minimum arcana needed to learn from it, then further reduced to a tenth.",
@@ -18,13 +24,20 @@
     "max_level": 2,
     "intelligence": 8,
     "time": "10 m",
-    "fun": -1
+    "fun": -1,
+    "flags": [ "SNIPPET_NEEDS_LITERACY" ]
   },
   {
     "id": "book_potioncraft",
     "type": "BOOK",
     "name": { "str": "History of Alchemy", "str_pl": "copies of History of Alchemy" },
-    "description": "A series of translated, annotated excerpts from several ancient books on the concept of alchemy.  This book presents an unconventional interpretation of the works discussed, haphazardly segueing into the author's own failed attempt to create the \"lapis philosophorum\" and \"alkahest\".  Some of the unconventional chemistry discussed might still be useful.\n\"Through all the cycles of putrefaction and purification, we have fallen short of refinement into the Rubedo stage.  We are missing a catalyst, something even purer than gold, energy embodied in matter…\"",
+    "description": "A series of translated, annotated excerpts from several ancient books on the concept of alchemy.  This book presents an unconventional interpretation of the works discussed, haphazardly segueing into the author's own failed attempt to create the \"lapis philosophorum\" and \"alkahest\".  Some of the unconventional chemistry discussed might still be useful.",
+    "snippet_category": [
+      {
+        "id": "book_potioncraft_1",
+        "text": "A series of translated, annotated excerpts from several ancient books on the concept of alchemy.  This book presents an unconventional interpretation of the works discussed, haphazardly segueing into the author's own failed attempt to create the \"lapis philosophorum\" and \"alkahest\".  Some of the unconventional chemistry discussed might still be useful.\n\"Through all the cycles of putrefaction and purification, we have fallen short of refinement into the Rubedo stage.  We are missing a catalyst, something even purer than gold, energy embodied in matter…\""
+      }
+    ],
     "weight": "454 g",
     "volume": "1 L",
     "price": "150 USD",
@@ -38,14 +51,21 @@
     "max_level": 3,
     "intelligence": 9,
     "time": "10 m",
-    "fun": 0
+    "fun": 0,
+    "flags": [ "SNIPPET_NEEDS_LITERACY" ]
   },
   {
     "id": "book_scrollcraft",
     "type": "BOOK",
     "name": { "str": "The Six Pillars", "str_pl": "copies of The Six Pillars" },
     "//": "Implies that interpreting the coded verses are the most difficult part, the magic itself is low-mid level in complexity.",
-    "description": "A book depicting six strange symbols on the cover.  The text uses mythological concepts and metaphors to disguise magical formulae, concealing its knowledge within stories of an otherworldly pantheon.\n\"Mother of the sun.  Maiden of moonlit storms.  Order woven into earth itself.  Chaos reveling in nature.  Four horsemen embodied as one.  Defiance and strife.  You are the keepers of all I know…\"",
+    "description": "A book depicting six strange symbols on the cover.  The text uses mythological concepts and metaphors to disguise magical formulae, concealing its knowledge within stories of an otherworldly pantheon.",
+    "snippet_category": [
+      {
+        "id": "book_scrollcraft_1",
+        "text": "A book depicting six strange symbols on the cover.  The text uses mythological concepts and metaphors to disguise magical formulae, concealing its knowledge within stories of an otherworldly pantheon.\n\"Mother of the sun.  Maiden of moonlit storms.  Order woven into earth itself.  Chaos reveling in nature.  Four horsemen embodied as one.  Defiance and strife.  You are the keepers of all I know…\""
+      }
+    ],
     "weight": "454 g",
     "volume": "1 L",
     "price": "250 USD",
@@ -60,13 +80,19 @@
     "intelligence": 11,
     "time": "40 m",
     "fun": -2,
-    "flags": [ "INSPIRATIONAL" ]
+    "flags": [ "INSPIRATIONAL", "SNIPPET_NEEDS_LITERACY" ]
   },
   {
     "id": "book_bloodmagic",
     "type": "BOOK",
     "name": { "str": "Sanguine Codex", "str_pl": "copies of Sanguine Codex" },
-    "description": "A book written in dark, brown ink that almost resembles dried blood.  It illustrates several painful-looking rituals for drawing powerful energy from the blood of living creatures, the practices of an order of blood mages.\n\"There is power in life itself.  There is a struggle, turmoil and chaos in it as well.  To follow The Path requires making proper use of said disharmony, even as one draws power from life…\"",
+    "description": "A book written in dark, brown ink that almost resembles dried blood.  It illustrates several painful-looking rituals for drawing powerful energy from the blood of living creatures, the practices of an order of blood mages.",
+    "snippet_category": [
+      {
+        "id": "book_bloodmagic_1",
+        "text": "A book written in dark, brown ink that almost resembles dried blood.  It illustrates several painful-looking rituals for drawing powerful energy from the blood of living creatures, the practices of an order of blood mages.\n\"There is power in life itself.  There is a struggle, turmoil and chaos in it as well.  To follow The Path requires making proper use of said disharmony, even as one draws power from life…\""
+      }
+    ],
     "weight": "454 g",
     "volume": "1 L",
     "price": "300 USD",
@@ -81,13 +107,19 @@
     "intelligence": 10,
     "time": "20 m",
     "fun": -3,
-    "flags": [ "BOOK_CANNIBAL" ]
+    "flags": [ "BOOK_CANNIBAL", "SNIPPET_NEEDS_LITERACY" ]
   },
   {
     "id": "book_hexenhammer",
     "type": "BOOK",
     "name": { "str": "The Cleansing Flame", "str_pl": "copies of The Cleansing Flame" },
-    "description": "A book written by some esoteric religious order, dedicated to destroying the otherworldly things intruding upon this realm.  The tools of their trade rely on a sanctioned form of magic, using \"consecrated\" essence they deemed safe to use.\n\"To bring justice to those who would endanger humanity, if we must.  To mend the growing wound In The Veil Between Worlds, if we can.  To guard and guide, so that a dangerous path may be avoided, so we shall.  So long as the Sun shines upon the Earth.\"",
+    "description": "A book written by some esoteric religious order, dedicated to destroying the otherworldly things intruding upon this realm.  The tools of their trade rely on a sanctioned form of magic, using \"consecrated\" essence they deemed safe to use.",
+    "snippet_category": [
+      {
+        "id": "book_hexenhammer_1",
+        "text": "A book written by some esoteric religious order, dedicated to destroying the otherworldly things intruding upon this realm.  The tools of their trade rely on a sanctioned form of magic, using \"consecrated\" essence they deemed safe to use.\n\"To bring justice to those who would endanger humanity, if we must.  To mend the growing wound In The Veil Between Worlds, if we can.  To guard and guide, so that a dangerous path may be avoided, so we shall.  So long as the Sun shines upon the Earth.\""
+      }
+    ],
     "weight": "454 g",
     "volume": "1 L",
     "price": "350 USD",
@@ -102,13 +134,19 @@
     "intelligence": 9,
     "time": "20 m",
     "fun": -1,
-    "flags": [ "INSPIRATIONAL" ]
+    "flags": [ "INSPIRATIONAL", "SNIPPET_NEEDS_LITERACY" ]
   },
   {
     "id": "book_sacrifice",
     "type": "BOOK",
     "name": { "str": "Oaths to the Chalice", "str_pl": "copies of Oaths to the Chalice" },
-    "description": "A strange book with a trident motif on the cover, describing the morbid rituals of some otherworldly cult, preaching of He From Beyond The Veil.  The level of detail these rituals go into is disturbing, yet informative.\n\"Through my visions, I saw rolling fog sweep across the valleys of a thousand worlds.  I witnessed the decay of countless cities, built by endless unnamed things.  And there, shadows coalesced into form, a presence to guide me…\"",
+    "description": "A strange book with a trident motif on the cover, describing the morbid rituals of some otherworldly cult, preaching of He From Beyond The Veil.  The level of detail these rituals go into is disturbing, yet informative.",
+    "snippet_category": [
+      {
+        "id": "book_sacrifice_1",
+        "text": "A strange book with a trident motif on the cover, describing the morbid rituals of some otherworldly cult, preaching of He From Beyond The Veil.  The level of detail these rituals go into is disturbing, yet informative.\n\"Through my visions, I saw rolling fog sweep across the valleys of a thousand worlds.  I witnessed the decay of countless cities, built by endless unnamed things.  And there, shadows coalesced into form, a presence to guide me…\""
+      }
+    ],
     "weight": "454 g",
     "volume": "1 L",
     "price": "400 USD",
@@ -123,13 +161,19 @@
     "intelligence": 10,
     "time": "30 m",
     "fun": -3,
-    "flags": [ "INSPIRATIONAL", "MORBID" ]
+    "flags": [ "INSPIRATIONAL", "MORBID", "SNIPPET_NEEDS_LITERACY" ]
   },
   {
     "id": "book_syncretism",
     "type": "BOOK",
     "name": { "str": "A Story in Shadow", "str_pl": "copies of A Story in Shadow" },
-    "description": "A book discussing the histories of a few peculiar cults and religious orders, and their conflicts during the years up until shortly before the cataclysm.  It describes a number of peculiar rituals and concepts based on the philosophies of the major groups mentioned, along with musing on their respective strengths and flaws.\n\"Athame, hammer, and chalice.  Stalking and warring over trifling powers, as the Blind World pursued the End of All.  All things are, and shall be, as was written…\"",
+    "description": "A book discussing the histories of a few peculiar cults and religious orders, and their conflicts during the years up until shortly before the cataclysm.  It describes a number of peculiar rituals and concepts based on the philosophies of the major groups mentioned, along with musing on their respective strengths and flaws.",
+    "snippet_category": [
+      {
+        "id": "book_syncretism_1",
+        "text": "A book discussing the histories of a few peculiar cults and religious orders, and their conflicts during the years up until shortly before the cataclysm.  It describes a number of peculiar rituals and concepts based on the philosophies of the major groups mentioned, along with musing on their respective strengths and flaws.\n\"Athame, hammer, and chalice.  Stalking and warring over trifling powers, as the Blind World pursued the End of All.  All things are, and shall be, as was written…\""
+      }
+    ],
     "weight": "454 g",
     "volume": "1 L",
     "price": "450 USD",
@@ -143,13 +187,20 @@
     "max_level": 9,
     "intelligence": 10,
     "time": "45 m",
-    "fun": -2
+    "fun": -2,
+    "flags": [ "SNIPPET_NEEDS_LITERACY" ]
   },
   {
     "id": "book_summoning",
     "type": "BOOK",
     "name": { "str": "To Master the Unknown", "str_pl": "copies of To Master the Unknown" },
-    "description": "A book describing several otherworldly creatures and their origins, or at least conjecture on those origins.  Stranger still, it describes experiments in summoning and  …controlling them?\n\"In the absence of an adequate catalyst, those who dwell Beyond are not easily called into service.  What slips through the cracks most readily is a mere shadow, a reflection of shadows even, given form that can be tamed…\"",
+    "description": "A book describing several otherworldly creatures and their origins, or at least conjecture on those origins.  Stranger still, it describes experiments in summoning and  …controlling them?",
+    "snippet_category": [
+      {
+        "id": "book_summoning_1",
+        "text": "A book describing several otherworldly creatures and their origins, or at least conjecture on those origins.  Stranger still, it describes experiments in summoning and  …controlling them?\n\"In the absence of an adequate catalyst, those who dwell Beyond are not easily called into service.  What slips through the cracks most readily is a mere shadow, a reflection of shadows even, given form that can be tamed…\""
+      }
+    ],
     "weight": "454 g",
     "volume": "1 L",
     "price": "500 USD",
@@ -164,7 +215,7 @@
     "intelligence": 11,
     "time": "45 m",
     "fun": -3,
-    "flags": [ "MORBID" ]
+    "flags": [ "MORBID", "SNIPPET_NEEDS_LITERACY" ]
   },
   {
     "id": "recipe_lab_arcana",

--- a/Arcana_BN/items/classes.json
+++ b/Arcana_BN/items/classes.json
@@ -10,7 +10,7 @@
     "symbol": ",",
     "looks_like": "survnote",
     "color": "white",
-    "flags": [ "NO_SALVAGE" ]
+    "flags": [ "NO_SALVAGE", "SNIPPET_NEEDS_LITERACY" ]
   },
   {
     "abstract": "spell_base",

--- a/Arcana_BN/items/tools.json
+++ b/Arcana_BN/items/tools.json
@@ -1311,7 +1311,20 @@
       {
         "type": "repair_item",
         "item_action_type": "repair_metal",
-        "materials": [ "iron", "steel", "budget_steel", "hardsteel", "aluminum", "copper", "bronze", "silver", "gold", "platinum", "superalloy", "glass" ],
+        "materials": [
+          "iron",
+          "steel",
+          "budget_steel",
+          "hardsteel",
+          "aluminum",
+          "copper",
+          "bronze",
+          "silver",
+          "gold",
+          "platinum",
+          "superalloy",
+          "glass"
+        ],
         "skill": "magic",
         "tool_quality": 20,
         "cost_scaling": 0,
@@ -1666,7 +1679,13 @@
     "type": "TOOL",
     "copy-from": "zweihander",
     "name": { "str": "cursed blade" },
-    "description": "A two-handed sword made of a dark metal.  It is engraved with unfamiliar symbols, and a single phrase in a script you can actually read: \"neherit asheiri\"  Activating it will grant the wielder a burst of powerful, corruptive, addictive life-draining magic, but you'll be unable to let go of it until the effect wears off.",
+    "description": "A two-handed sword made of a dark metal.  It is engraved with unfamiliar symbols that seem faintly foreboding.  Activating it will grant the wielder a burst of powerful, corruptive, addictive life-draining magic, but you'll be unable to let go of it until the effect wears off.",
+    "snippet_category": [
+      {
+        "id": "stormbringer_1",
+        "text": "A two-handed sword made of a dark metal.  It is engraved with unfamiliar symbols, and a single phrase in a script you can actually read: \"neherit asheiri\"  Activating it will grant the wielder a burst of powerful, corruptive, addictive life-draining magic, but you'll be unable to let go of it until the effect wears off."
+      }
+    ],
     "material": [ "steel", "essencemat" ],
     "//": "In this case being cursed basically halves its pre-cataclysm value, as it's no longer useful for what the Keepers used it for, and the Sanguine Order's appropriation of it had a very specific focus.",
     "weight": "2267 g",
@@ -1704,7 +1723,7 @@
         "type": "transform"
       }
     ],
-    "extend": { "flags": [ "UNBREAKABLE_MELEE", "NO_SALVAGE" ] },
+    "extend": { "flags": [ "UNBREAKABLE_MELEE", "NO_SALVAGE", "SNIPPET_NEEDS_LITERACY" ] },
     "delete": { "flags": [ "DURABLE_MELEE", "ALWAYS_TWOHAND" ] }
   },
   {

--- a/Arcana_BN/modinfo.json
+++ b/Arcana_BN/modinfo.json
@@ -5,7 +5,7 @@
     "name": "<color_cyan>Arcana and Magic Items</color>",
     "authors": [ "Chaosvolt" ],
     "description": "Adds a host of craftable magic items and spells, centered around the use of Arcana skill to research and exploit otherworldly monsters and anomalies.",
-    "version": "BN version, update 11/10/2024",
+    "version": "BN version, update 11/11/2024",
     "category": "content",
     "dependencies": [ "bn" ]
   }


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5698 is merged. Adds the new flag to the item all notes in Arcana inherit from. In addition, arcanist books now have their full description moved to an internal snippet, with the baseline description omitting the flavor quote, and likewise the cursed blade no longer implies illiterate characters can make out a single phrase among the engravings.