### PR TITLE
Pending BN Update: Phasing out of `HAND_AXES` weapon category

### DIFF
--- a/Arcana_BN/items/tools.json
+++ b/Arcana_BN/items/tools.json
@@ -936,7 +936,7 @@
     "//": "Can't use copy-from because qualities refuse to be deleted, causing it to try and chop wood instead of exploding.",
     "type": "TOOL",
     "category": "weapons",
-    "weapon_category": [ "HAND_AXES" ],
+    "weapon_category": [ "1H_AXES" ],
     "name": { "str": "glowing veinreaver" },
     "description": "A modified hatchet, the axehead giving off a wicked red glow.  Throwing it might be a smart idea, as you'll have little time to evade its blast.",
     "weight": "707 g",

--- a/Arcana_BN/martialarts.json
+++ b/Arcana_BN/martialarts.json
@@ -234,7 +234,6 @@
       "STILETTOS",
       "KNIVES",
       "1H_HOOKED",
-      "HAND_AXES",
       "1H_AXES",
       "2H_AXES",
       "SHORT_SWORDS",

--- a/Arcana_BN/modinfo.json
+++ b/Arcana_BN/modinfo.json
@@ -5,7 +5,7 @@
     "name": "<color_cyan>Arcana and Magic Items</color>",
     "authors": [ "Chaosvolt" ],
     "description": "Adds a host of craftable magic items and spells, centered around the use of Arcana skill to research and exploit otherworldly monsters and anomalies.",
-    "version": "BN version, update 1/23/2025",
+    "version": "BN version, update 1/27/2025",
     "category": "content",
     "dependencies": [ "bn" ]
   }


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5994 is merged, switching uses of `HAND_AXES` weapon category for `1H_AXES`.