### PR TITLE
Ammo Overhaul compatibility update

### DIFF
--- a/Arcana/item_groups/item_groups_sanguine.json
+++ b/Arcana/item_groups/item_groups_sanguine.json
@@ -56,7 +56,7 @@
       [ "dao", 35 ],
       [ "khopesh", 10 ],
       [ "q_staff", 5 ],
-      { "collection": [ { "group": "ammo_pistol_reloaded" } ], "prob": 10 },
+      { "collection": [ { "group": "ammo_common_boxed" } ], "prob": 10 },
       [ "pistol_flintlock", 5 ],
       [ "flintlock_ammo", 10 ],
       [ "robe", 10 ],

--- a/Arcana/mod_interactions/magiclysm/monster_drops.json
+++ b/Arcana/mod_interactions/magiclysm/monster_drops.json
@@ -189,7 +189,7 @@
       { "group": "forge_life", "prob": 40 },
       { "group": "bedroom", "prob": 1 },
       { "group": "dresser", "prob": 5 },
-      { "group": "ammo", "prob": 18 }
+      { "group": "ammo_common_loose", "prob": 18 }
     ]
   },
   {

--- a/Arcana/npcs/missiondef.json
+++ b/Arcana/npcs/missiondef.json
@@ -688,7 +688,7 @@
           { "group": "drugs_heal_simple", "x": 14, "y": 10, "repeat": 5, "chance": 50 },
           { "group": "weapons", "x": 14, "y": 12, "repeat": 2, "chance": 25 },
           { "group": "guns_survival", "x": 14, "y": 12, "repeat": 2, "chance": 25 },
-          { "group": "ammo_reloaded", "x": 14, "y": 12, "repeat": 5, "chance": 50 },
+          { "group": "ammo_common_boxed", "x": 14, "y": 12, "repeat": 5, "chance": 50 },
           { "item": "shovel", "x": 14, "y": 12, "chance": 80 },
           { "group": "remains_soldier", "x": 10, "y": 16, "chance": 100 },
           { "item": "223_casing", "x": [ 10, 15 ], "y": [ 13, 15 ], "repeat": 10, "chance": 50 },

--- a/Arcana/overmap_and_mapgen/mapgen_basements.json
+++ b/Arcana/overmap_and_mapgen/mapgen_basements.json
@@ -335,7 +335,7 @@
             { "item": "magic_crafting", "chance": 10 },
             { "item": "magic_crafting", "chance": 10 },
             { "item": "ammo_common", "chance": 50 },
-            { "item": "ammo_reloaded", "chance": 75 },
+            { "item": "ammo_common_boxed", "chance": 75 },
             { "item": "guns_common", "chance": 25 },
             { "item": "guns_improvised", "chance": 50 }
           ]
@@ -415,7 +415,7 @@
             { "item": "magic_crafting", "chance": 10 },
             { "item": "magic_crafting", "chance": 10 },
             { "item": "ammo_common", "chance": 50 },
-            { "item": "ammo_reloaded", "chance": 75 },
+            { "item": "ammo_common_boxed", "chance": 75 },
             { "item": "guns_common", "chance": 25 },
             { "item": "guns_improvised", "chance": 50 }
           ]
@@ -558,7 +558,7 @@
           "ammo": 75,
           "magazine": 100
         },
-        { "group": "ammo_reloaded", "x": 19, "y": 5, "chance": 100, "repeat": [ 1, 3 ], "magazine": 100 },
+        { "group": "ammo_common_boxed", "x": 19, "y": 5, "chance": 100, "repeat": [ 1, 3 ], "magazine": 100 },
         { "group": "guns_pistol_common", "x": 15, "y": 10, "chance": 30, "ammo": 75, "magazine": 100 },
         { "group": "guns_pistol_common", "x": 21, "y": 10, "chance": 30, "ammo": 75, "magazine": 100 },
         { "group": "clothing_outdoor_set", "x": 15, "y": 10, "chance": 30 },

--- a/Arcana/overmap_and_mapgen/mapgen_purifer_ambushed.json
+++ b/Arcana/overmap_and_mapgen/mapgen_purifer_ambushed.json
@@ -107,7 +107,7 @@
         { "item": "bone_human", "x": [ 18, 19 ], "y": 18, "chance": 50, "repeat": 10 },
         { "group": "kitchen_counters", "x": [ 18, 19 ], "y": 18, "chance": 50, "repeat": 4 },
         { "item": "cookbook_human", "x": [ 18, 19 ], "y": 18 },
-        { "group": "ammo_reloaded", "x": [ 21, 22 ], "y": 18, "chance": 50, "repeat": 8 },
+        { "group": "ammo_common_boxed", "x": [ 21, 22 ], "y": 18, "chance": 50, "repeat": 8 },
         { "group": "behindcounter", "x": [ 4, 6 ], "y": 21, "chance": 75, "repeat": 3 },
         { "group": "meth_ingredients", "x": [ 9, 13 ], "y": 21, "chance": 80, "repeat": 7 },
         { "group": "stash_drugs", "x": 21, "y": 21, "chance": 50, "repeat": 5 },

--- a/Arcana/overmap_and_mapgen/mapgen_update.json
+++ b/Arcana/overmap_and_mapgen/mapgen_update.json
@@ -352,7 +352,7 @@
       ],
       "place_nested": [ { "chunks": [ "cf_church_upgrade_4_d" ], "x": 4, "y": 17 } ],
       "place_loot": [
-        { "group": "ammo_reloaded", "x": [ 4, 6 ], "y": 17, "chance": 75, "repeat": 7 },
+        { "group": "ammo_common_boxed", "x": [ 4, 6 ], "y": 17, "chance": 75, "repeat": 7 },
         { "group": "arcana_purifying_shot_group", "x": [ 4, 6 ], "y": 17, "chance": 75, "repeat": 3 },
         { "group": "guns_milspec", "x": 4, "y": [ 19, 20 ], "chance": 75, "repeat": 5 },
         { "group": "rural_church_start_scales", "x": 4, "y": 19 }
@@ -424,7 +424,7 @@
       "place_loot": [
         { "group": "preserved_food", "x": [ 4, 6 ], "y": 20, "chance": 50, "repeat": 10 },
         { "group": "tools_hunting", "x": [ 4, 5 ], "y": 17, "chance": 50, "repeat": 5 },
-        { "group": "ammo_reloaded", "x": [ 4, 5 ], "y": 17, "chance": 75, "repeat": 5 },
+        { "group": "ammo_common_boxed", "x": [ 4, 5 ], "y": 17, "chance": 75, "repeat": 5 },
         { "group": "rural_church_start_scales", "x": 5, "y": 17 }
       ],
       "faction_owner": [ { "id": "cleansing_flame_aux", "x": [ 4, 6 ], "y": [ 17, 20 ] } ],
@@ -460,7 +460,7 @@
         { "group": "wood_workshop", "x": [ 4, 5 ], "y": 20, "chance": 50, "repeat": 10 },
         { "group": "preserved_food", "x": 6, "y": 20, "chance": 50, "repeat": 10 },
         { "group": "tools_hunting", "x": [ 4, 5 ], "y": 17, "chance": 50, "repeat": 5 },
-        { "group": "ammo_reloaded", "x": [ 4, 5 ], "y": 17, "chance": 75, "repeat": 5 },
+        { "group": "ammo_common_boxed", "x": [ 4, 5 ], "y": 17, "chance": 75, "repeat": 5 },
         { "group": "arcana_purifying_shot_group", "x": [ 4, 5 ], "y": 17, "chance": 50, "repeat": 5 },
         { "group": "rural_church_start_scales", "x": 5, "y": 17 }
       ],
@@ -506,7 +506,7 @@
       ],
       "place_nested": [ { "chunks": [ "cf_church_upgrade_4_d" ], "x": 4, "y": 17 } ],
       "place_loot": [
-        { "group": "ammo_reloaded", "x": [ 4, 5 ], "y": 17, "chance": 75, "repeat": 7 },
+        { "group": "ammo_common_boxed", "x": [ 4, 5 ], "y": 17, "chance": 75, "repeat": 7 },
         { "group": "arcana_purifying_shot_group", "x": [ 4, 5 ], "y": 17, "chance": 75, "repeat": 5 },
         { "group": "drugs_soldier", "x": 6, "y": 17, "chance": 75, "repeat": 10 },
         { "group": "rural_church_medical_items", "x": 6, "y": 17, "chance": 75, "repeat": 5 },


### PR DESCRIPTION
There was update that causes many errors.
https://github.com/CleverRaven/Cataclysm-DDA/pull/79952 What caused "two mission defenition from same source" was most nasty to locate and figuire out where error.