### PR TITLE
Pending BN Feature: `UNBREAKABLE` flag

### DIFF
--- a/Arcana/items/tool_armor.json
+++ b/Arcana/items/tool_armor.json
@@ -550,16 +550,7 @@
         }
       ]
     },
-    "flags": [
-      "ALLOWS_NATURAL_ATTACKS",
-      "OVERSIZE",
-      "STURDY",
-      "UNBREAKABLE_MELEE",
-      "BLOCK_WHILE_WORN",
-      "NO_SALVAGE",
-      "AURA",
-      "POWERARMOR_COMPATIBLE"
-    ],
+    "flags": [ "ALLOWS_NATURAL_ATTACKS", "OVERSIZE", "STURDY", "BLOCK_WHILE_WORN", "NO_SALVAGE", "AURA", "POWERARMOR_COMPATIBLE" ],
     "max_worn": 1,
     "sided": true,
     "material_thickness": 4,
@@ -594,7 +585,8 @@
         "WATERPROOF",
         "ZERO_WEIGHT",
         "ELECTRIC_IMMUNE",
-        "DIMENSIONAL_ANCHOR"
+        "DIMENSIONAL_ANCHOR",
+        "UNBREAKABLE"
       ]
     }
   },
@@ -663,7 +655,7 @@
       "ammo_scale": 0
     },
     "qualities": [ [ "GLARE", 1 ] ],
-    "extend": { "flags": [ "GAS_PROOF", "RAD_PROOF", "SUN_GLASSES", "BULLET_IMMUNE", "STAB_IMMUNE", "HEAT_IMMUNE" ] }
+    "extend": { "flags": [ "GAS_PROOF", "RAD_PROOF", "SUN_GLASSES", "BULLET_IMMUNE", "STAB_IMMUNE", "HEAT_IMMUNE", "UNBREAKABLE" ] }
   },
   {
     "id": "armor_wyrm_berserker",

--- a/Arcana_BN/items/tool_armor.json
+++ b/Arcana_BN/items/tool_armor.json
@@ -496,7 +496,6 @@
       "ALLOWS_NATURAL_ATTACKS",
       "OVERSIZE",
       "STURDY",
-      "UNBREAKABLE_MELEE",
       "BLOCK_WHILE_WORN",
       "NO_SALVAGE",
       "AURA",
@@ -531,7 +530,8 @@
         "TRADER_AVOID",
         "WATERPROOF",
         "ELECTRIC_IMMUNE",
-        "DIMENSIONAL_ANCHOR"
+        "DIMENSIONAL_ANCHOR",
+        "UNBREAKABLE"
       ]
     }
   },
@@ -596,7 +596,18 @@
     "revert_to": "hauberk_jade",
     "use_action": { "target": "hauberk_jade", "msg": "The glow emanating from your jade hauberk fades.", "type": "transform" },
     "qualities": [ [ "GLARE", 1 ] ],
-    "extend": { "flags": [ "GAS_PROOF", "RAD_PROOF", "SUN_GLASSES", "CUT_IMMUNE", "STAB_IMMUNE", "HEAT_IMMUNE", "CLIMATE_CONTROL" ] }
+    "extend": {
+      "flags": [
+        "GAS_PROOF",
+        "RAD_PROOF",
+        "SUN_GLASSES",
+        "CUT_IMMUNE",
+        "STAB_IMMUNE",
+        "HEAT_IMMUNE",
+        "CLIMATE_CONTROL",
+        "UNBREAKABLE"
+      ]
+    }
   },
   {
     "id": "armor_wyrm_berserker",


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6270 is merged. Applies the `UNBREAKABLE` flag to active cyclopean mirror and active jade hauberk.