### PR TITLE
[DDA] Fix mapgen duplicate definition

### DIFF
--- a/Arcana/overmap_and_mapgen/mapgen_sanguine_holdout.json
+++ b/Arcana/overmap_and_mapgen/mapgen_sanguine_holdout.json
@@ -7,12 +7,12 @@
     "object": {
       "rows": [
         ",,,,,,,,,,,,,,,,,,,,,,,,",
-        ",,,PPPPPPPPPPGGGGGPPPP,,",
-        ",,,P%,,%%%%%,,,,,,!,%P,,",
-        ",,,P%,,,,,,,,,,,,,,,%P,,",
-        ",,,P%,|-www-|,,,,,,,%P,,",
-        ",,,P,,|CsfCn|EEEEE,,%P,,",
-        ",,|-w-|o....+EEEEE,,,P,,",
+        ",,,YYYYYYYYYYGGGGGYYYY,,",
+        ",,,Y%,,%%%%%,,,,,,!,%Y,,",
+        ",,,Y%,,,,,,,,,,,,,,,%Y,,",
+        ",,,Y%,|-www-|,,,,,,,%Y,,",
+        ",,,Y,,|CsfCn|EEEEE,,%Y,,",
+        ",,|-w-|o....+EEEEE,,,Y,,",
         ",,|t.&|C...n|-www-|-w-|,",
         ",?|t..+....n|D....+..{|,",
         ",,|..s|.....+.....+..{|,",
@@ -54,11 +54,10 @@
           [ "t_shrub_rose", 25 ]
         ],
         "G": "t_palisade_gate",
-        "P": "t_palisade",
+        "Y": "t_palisade",
         "W": "t_window_boarded",
         "w": "t_window_domestic"
       },
-      "terrain": { "P": "f_null" },
       "place_loot": [ { "item": "candle_warding_active", "x": 17, "y": 15 } ],
       "place_zones": [
         { "type": "NPC_NO_INVESTIGATE", "faction": "sanguine_order_remnant", "x": [ 0, 23 ], "y": [ 0, 10 ] },
@@ -153,12 +152,12 @@
     "object": {
       "rows": [
         ",,,,,,,,,,,,,,,,,,,,,,,,",
-        ",,,PPPPPPPPPPGGGGGPPPP,,",
-        ",,,P%,,%%%%%,,,,,,!,%P,,",
-        ",,,P%,,,,,,,,,,,,,,,%P,,",
-        ",,,P%,|-www-|,,,,,,,%P,,",
-        ",,,P,,|}..DB|EEEEE,,%P,,",
-        ",,|---|h...B|EEEEE,,,P,,",
+        ",,,YYYYYYYYYYGGGGGYYYY,,",
+        ",,,Y%,,%%%%%,,,,,,!,%Y,,",
+        ",,,Y%,,,,,,,,,,,,,,,%Y,,",
+        ",,,Y%,|-www-|,,,,,,,%Y,,",
+        ",,,Y,,|}..DB|EEEEE,,%Y,,",
+        ",,|---|h...B|EEEEE,,,Y,,",
         ",,|&.s|dd...|-w+w-|---|,",
         ",?|...+.....|BD...|s.&|,",
         ",,|tt.|.....|B....+...|,",
@@ -217,11 +216,10 @@
           [ "t_shrub_rose", 25 ]
         ],
         "G": "t_palisade_gate",
-        "P": "t_palisade",
+        "Y": "t_palisade",
         "W": "t_window_boarded",
         "w": "t_window_domestic"
       },
-      "terrain": { "P": "f_null" },
       "place_zones": [ { "type": "NPC_INVESTIGATE_ONLY", "faction": "sanguine_order_remnant", "x": [ 3, 21 ], "y": [ 5, 20 ] } ],
       "place_npcs": [
         { "class": "sanguine_order_shrike_huntmaster", "x": 5, "y": 14, "add_trait": "SHRIKE_MISSION_MARKER" },


### PR DESCRIPTION
The sanguine holdout had a duplicate terrain field to get rid of the portal overlay.  Unfortunately just moving it into the existing furniture array with f_null didn't actually result in removing the portals from the mapgen, so I just swapped the walls definition from P to Y

Test:
![holdout fix](https://github.com/user-attachments/assets/f6a910fd-dafb-4f49-8e1a-fd16b2935026)

Unfortunately I don't have Bright Nights to test if this fix works there or if its even an issue