### PR TITLE
Update some field names and weight formats to work with DDA changes

### DIFF
--- a/Arcana/items/books.json
+++ b/Arcana/items/books.json
@@ -14,12 +14,12 @@
     "symbol": "?",
     "looks_like": "recipe_creepy",
     "color": "light_gray",
-    "skill": "magic",
+    "read_skill": "magic",
     "required_level": 0,
     "max_level": 2,
     "intelligence": 8,
     "time": "10 m",
-    "fun": -1
+    "read_fun": -1
   },
   {
     "id": "book_potioncraft",
@@ -35,12 +35,12 @@
     "symbol": "?",
     "looks_like": "textbook_gaswarfare",
     "color": "green",
-    "skill": "magic",
+    "read_skill": "magic",
     "required_level": 0,
     "max_level": 3,
     "intelligence": 9,
     "time": "10 m",
-    "fun": 0
+    "read_fun": 0
   },
   {
     "id": "book_scrollcraft",
@@ -57,12 +57,12 @@
     "symbol": "?",
     "looks_like": "book_philosophy",
     "color": "brown",
-    "skill": "magic",
+    "read_skill": "magic",
     "required_level": 2,
     "max_level": 5,
     "intelligence": 11,
     "time": "40 m",
-    "fun": -2,
+    "read_fun": -2,
     "flags": [ "INSPIRATIONAL" ]
   },
   {
@@ -79,12 +79,12 @@
     "symbol": "?",
     "looks_like": "textbook_chemistry",
     "color": "red",
-    "skill": "magic",
+    "read_skill": "magic",
     "required_level": 3,
     "max_level": 6,
     "intelligence": 10,
     "time": "20 m",
-    "fun": -3
+    "read_fun": -3
   },
   {
     "id": "book_hexenhammer",
@@ -100,12 +100,12 @@
     "symbol": "?",
     "looks_like": "holybook_bible2",
     "color": "light_blue",
-    "skill": "magic",
+    "read_skill": "magic",
     "required_level": 4,
     "max_level": 7,
     "intelligence": 9,
     "time": "20 m",
-    "fun": -1,
+    "read_fun": -1,
     "flags": [ "INSPIRATIONAL" ]
   },
   {
@@ -122,12 +122,12 @@
     "symbol": "?",
     "looks_like": "holybook_bible1",
     "color": "blue",
-    "skill": "magic",
+    "read_skill": "magic",
     "required_level": 5,
     "max_level": 8,
     "intelligence": 10,
     "time": "30 m",
-    "fun": -3,
+    "read_fun": -3,
     "flags": [ "INSPIRATIONAL" ]
   },
   {
@@ -144,12 +144,12 @@
     "symbol": "?",
     "looks_like": "holybook_kojiki",
     "color": "light_gray",
-    "skill": "magic",
+    "read_skill": "magic",
     "required_level": 6,
     "max_level": 10,
     "intelligence": 10,
     "time": "45 m",
-    "fun": -2
+    "read_fun": -2
   },
   {
     "id": "book_summoning",
@@ -165,12 +165,12 @@
     "symbol": "?",
     "looks_like": "welding_book",
     "color": "dark_gray",
-    "skill": "magic",
+    "read_skill": "magic",
     "required_level": 6,
     "max_level": 10,
     "intelligence": 11,
     "time": "45 m",
-    "fun": -3
+    "read_fun": -3
   },
   {
     "id": "recipe_lab_arcana",
@@ -186,12 +186,12 @@
     "symbol": "?",
     "looks_like": "recipe_lab_elec",
     "color": "light_green",
-    "skill": "magic",
+    "read_skill": "magic",
     "required_level": 5,
     "max_level": 8,
     "intelligence": 12,
     "time": "45 m",
-    "fun": -2
+    "read_fun": -2
   },
   {
     "id": "note_grove",
@@ -468,7 +468,7 @@
     "color": "light_gray",
     "intelligence": 12,
     "time": "30 m",
-    "fun": -1,
+    "read_fun": -1,
     "flags": [ "TRADER_AVOID" ]
   },
   {
@@ -484,7 +484,7 @@
     "color": "light_gray",
     "intelligence": 14,
     "time": "45 m",
-    "fun": -2,
+    "read_fun": -2,
     "flags": [ "TRADER_AVOID" ]
   },
   {
@@ -541,12 +541,12 @@
     "symbol": "?",
     "looks_like": "alloy_plate",
     "color": "light_gray",
-    "skill": "magic",
+    "read_skill": "magic",
     "required_level": 9,
     "max_level": 10,
     "intelligence": 16,
     "time": "45 m",
-    "fun": -2,
+    "read_fun": -2,
     "flags": [ "NO_SALVAGE", "TRADER_AVOID" ]
   }
 ]

--- a/Arcana/items/tool_armor.json
+++ b/Arcana/items/tool_armor.json
@@ -8,7 +8,7 @@
     "description": "A wreath of brightly-colored flowers from another world, worn around the neck.  Elemental magic has been woven into its structure, converting it into a primitive magic item.  Using it will grant a burst of renewed stamina, recovering pain and speeding up the body's natural healing.  It will take a long time to recharge after each use, and activating it also fatigues the user.  It can hold up to 5 uses, each use takes 25 hours to charge.",
     "price_postapoc": "12 USD",
     "charges_per_use": 25,
-    "ammo": "primitive_magic_item_ammo_type",
+    "tool_ammo": "primitive_magic_item_ammo_type",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "primitive_magic_item_ammo_type": 125 } } ],
     "flags": [ "NO_RELOAD", "NO_UNLOAD", "TARDIS" ],
     "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "1 h", "regenerate_ammo": true } },
@@ -24,7 +24,7 @@
     "description": "A makeshift necklace with a single gem, a charm worked from some manner of unnatural material.  Elemental magic has been woven into its structure, converting it into a primitive magic item.  Activating it will shroud your life force, rendering you invisible (but not inaudible) to the undead, in exchange for making mundane wildlife more aggressive towards you.  It will take a long time to recharge after each use, and activating it also fatigues the user.  It can hold up to 5 uses, each use takes 28 hours to charge.",
     "price_postapoc": "15 USD",
     "charges_per_use": 35,
-    "ammo": "primitive_magic_item_ammo_type",
+    "tool_ammo": "primitive_magic_item_ammo_type",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "primitive_magic_item_ammo_type": 175 } } ],
     "flags": [ "NO_RELOAD", "NO_UNLOAD", "TARDIS" ],
     "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "1 h", "regenerate_ammo": true } },
@@ -40,7 +40,7 @@
     "description": "A hand-crafted disc brooch made from a strange, unearthly material vaguely resembling mother-of-pearl  Elemental magic has been woven into its structure, converting it into a primitive magic item.  Using it will reduce all incoming damage by 25%.  It will take a long time to recharge after each use, and activating it also fatigues the user.  It can hold up to 5 uses, each use takes 45 hours to charge.",
     "price_postapoc": "20 USD",
     "charges_per_use": 45,
-    "ammo": "primitive_magic_item_ammo_type",
+    "tool_ammo": "primitive_magic_item_ammo_type",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "primitive_magic_item_ammo_type": 225 } } ],
     "flags": [ "NO_RELOAD", "NO_UNLOAD", "TARDIS" ],
     "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "1 h", "regenerate_ammo": true } },
@@ -61,9 +61,9 @@
     "color": "yellow",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 60 } } ],
     "charges_per_use": 60,
-    "ammo": "essence_dull_type",
+    "tool_ammo": "essence_dull_type",
     "use_action": { "type": "cast_spell", "spell_id": "arcana_item_gilded_aegis_healing", "no_fail": true, "level": 0, "need_worn": true },
-    "relative": { "weight": 3020 },
+    "relative": { "weight": "3020g" },
     "extend": { "flags": [ "NO_SALVAGE", "TRADER_KEEP_EQUIPPED" ] },
     "material_thickness": 5,
     "armor": [ { "encumbrance": 12, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
@@ -84,7 +84,7 @@
     "color": "light_red",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 24 } } ],
     "charges_per_use": 1,
-    "ammo": "essence_dull_type",
+    "tool_ammo": "essence_dull_type",
     "warmth": 10,
     "relic_data": {
       "passive_effects": [
@@ -149,7 +149,7 @@
     "color": "light_red",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 24 } } ],
     "charges_per_use": 1,
-    "ammo": "essence_dull_type",
+    "tool_ammo": "essence_dull_type",
     "relic_data": {
       "passive_effects": [
         {
@@ -236,7 +236,7 @@
     ],
     "warmth": 20,
     "charges_per_use": 2,
-    "ammo": "essence_blood_type",
+    "tool_ammo": "essence_blood_type",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 16 } } ],
     "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_wyrmskin_acid", "no_fail": true, "level": 0, "need_worn": true } ],
     "flags": [ "OVERSIZE", "NO_SALVAGE", "ALLOWS_NATURAL_ATTACKS", "TRADER_KEEP_EQUIPPED", "POCKETS", "STURDY" ]
@@ -258,7 +258,7 @@
     "color": "yellow",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 6 } } ],
     "charges_per_use": 2,
-    "ammo": "essence_blood_type",
+    "tool_ammo": "essence_blood_type",
     "relic_data": {
       "passive_effects": [
         {
@@ -318,7 +318,7 @@
     "material": [ "cotton" ],
     "color": "dark_gray",
     "charges_per_use": 1,
-    "ammo": "essence_type",
+    "tool_ammo": "essence_type",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 20 } } ],
     "relic_data": {
       "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "ench_effects": [ { "effect": "arcana_invis_lesser", "intensity": 1 } ] } ]
@@ -336,7 +336,7 @@
         "ammo_scale": 0
       }
     ],
-    "relative": { "weight": 616, "volume": -1 },
+    "relative": { "weight": "616g", "volume": "-1ml" },
     "extend": { "flags": [ "NO_SALVAGE", "TRADER_KEEP_EQUIPPED" ] },
     "material_thickness": 6,
     "armor": [ { "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 7, 7 ] } ]
@@ -381,7 +381,7 @@
     "warmth": 20,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 20 } } ],
     "charges_per_use": 1,
-    "ammo": "essence_type",
+    "tool_ammo": "essence_type",
     "relic_data": {
       "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "ench_effects": [ { "effect": "arcana_invis_lesser", "intensity": 1 } ] } ]
     },
@@ -434,7 +434,7 @@
     "material": [ "qt_steel", "qt_steel_chain", "silver" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 4 } } ],
     "charges_per_use": 1,
-    "ammo": "essence_type",
+    "tool_ammo": "essence_type",
     "use_action": [
       {
         "type": "cast_spell",
@@ -457,7 +457,7 @@
         "encumbrance": 16
       }
     ],
-    "relative": { "weight": 210 },
+    "relative": { "weight": "210g" },
     "extend": { "flags": [ "NO_SALVAGE", "TRADER_KEEP_EQUIPPED" ] }
   },
   {
@@ -474,7 +474,7 @@
     "warmth": 15,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 4 } } ],
     "charges_per_use": 1,
-    "ammo": "essence_type",
+    "tool_ammo": "essence_type",
     "use_action": [
       {
         "type": "cast_spell",
@@ -497,7 +497,7 @@
         "encumbrance": 12
       }
     ],
-    "relative": { "weight": 120 },
+    "relative": { "weight": "120g" },
     "extend": { "flags": [ "NO_SALVAGE", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE", "OUTER" ] }
   },
   {
@@ -517,7 +517,7 @@
     "looks_like": "shield_round",
     "color": "light_gray",
     "charges_per_use": 1,
-    "ammo": "essence_type",
+    "tool_ammo": "essence_type",
     "use_action": [
       {
         "target": "cyclopean_mirror_on",
@@ -611,7 +611,7 @@
         }
       ]
     },
-    "ammo": "essence_dull_type",
+    "tool_ammo": "essence_dull_type",
     "use_action": [
       {
         "target": "hauberk_jade_on",
@@ -673,7 +673,7 @@
     "looks_like": "armor_wyrm",
     "color": "light_gray",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 30 } } ],
-    "ammo": "essence_blood_type",
+    "tool_ammo": "essence_blood_type",
     "warmth": 20,
     "//": "Increased to be more on par with BN version's armor values.",
     "material_thickness": 5,
@@ -840,7 +840,7 @@
     "repairs_like": "revenant_crown",
     "color": "green",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 30 } } ],
-    "ammo": "essence_blood_type",
+    "tool_ammo": "essence_blood_type",
     "relic_data": {
       "passive_effects": [
         {
@@ -899,7 +899,7 @@
     "repairs_like": "mana_gem",
     "color": "light_gray",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 300 } } ],
-    "ammo": "essence_dull_type",
+    "tool_ammo": "essence_dull_type",
     "use_action": {
       "target": "meteoric_talisman_on",
       "msg": "As you activate the talisman, you feel insulated in a strange manner.",
@@ -948,7 +948,7 @@
     "color": "yellow",
     "charges_per_use": 1,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 10 } } ],
-    "ammo": "essence_pure_type",
+    "tool_ammo": "essence_pure_type",
     "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_divine_seal", "no_fail": true, "need_worn": true, "level": 0 } ],
     "relic_data": {
       "passive_effects": [
@@ -974,7 +974,7 @@
     "material": [ "silver", "essencemat" ],
     "color": "white",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 10 } } ],
-    "ammo": "essence_type",
+    "tool_ammo": "essence_type",
     "use_action": {
       "target": "cleric_ring_on",
       "msg": "A strange energy radiates from the ring's gem, spreading a calming sensation over you.",

--- a/Arcana/items/tools.json
+++ b/Arcana/items/tools.json
@@ -101,7 +101,7 @@
     "description": "A small talisman made out of some form of otherworldly bone or ivory, carved with equally unearthly iconography.  Elemental magic has been woven into its structure, converting it into a primitive magic item.  Using it will heavily damage and paralyze any hostiles within 4 tiles.  It will take a long time to recharge after each use, and activating it also fatigues the user.  It can hold up to 5 uses, each use takes 20 hours to charge.",
     "price_postapoc": "20 USD",
     "charges_per_use": 20,
-    "ammo": "primitive_magic_item_ammo_type",
+    "tool_ammo": "primitive_magic_item_ammo_type",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "primitive_magic_item_ammo_type": 100 } } ],
     "flags": [ "MAGIC_FOCUS", "NO_RELOAD", "NO_UNLOAD", "TARDIS" ],
     "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "1 h", "regenerate_ammo": true } },
@@ -117,7 +117,7 @@
     "description": "A polished flute with five finger holes, carved from the stinger of some exotic monstrosity.  Elemental magic has been woven into its structure, converting it into a primitive magic item.  Using it will greatly reduce movecosts and enhance evasion.  Stamina and attack speed are unaffected, however.  It will take a long time to recharge after each use, and activating it also fatigues the user.  It can hold up to 6 uses, each use takes 40 hours to charge.",
     "price_postapoc": "25 USD",
     "charges_per_use": 40,
-    "ammo": "primitive_magic_item_ammo_type",
+    "tool_ammo": "primitive_magic_item_ammo_type",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "primitive_magic_item_ammo_type": 200 } } ],
     "flags": [ "MAGIC_FOCUS", "NO_RELOAD", "NO_UNLOAD", "TARDIS" ],
     "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "1 h", "regenerate_ammo": true } },
@@ -207,7 +207,7 @@
     "looks_like": "arming_sword",
     "color": "yellow",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 20 } } ],
-    "ammo": "essence_dull_type",
+    "tool_ammo": "essence_dull_type",
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 10 ] ],
     "techniques": [ "WBLOCK_2" ],
     "use_action": [
@@ -261,7 +261,7 @@
     "material": [ { "type": "steel", "portion": 25 }, { "type": "wood", "portion": 25 }, { "type": "silver", "portion": 2 } ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 3 } } ],
     "charges_per_use": 3,
-    "ammo": "essence_dull_type",
+    "tool_ammo": "essence_dull_type",
     "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_hammerzeit", "no_fail": true, "need_wielding": true, "level": 0 } ],
     "relative": { "weight": "360 g", "melee_damage": { "bash": 2 } },
     "extend": { "flags": [ "NO_SALVAGE" ] }
@@ -279,7 +279,7 @@
     "material": [ { "type": "steel", "portion": 25 }, { "type": "wood", "portion": 25 }, { "type": "silver", "portion": 2 } ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 10 } } ],
     "charges_per_use": 10,
-    "ammo": "essence_dull_type",
+    "tool_ammo": "essence_dull_type",
     "use_action": [
       {
         "type": "cast_spell",
@@ -306,7 +306,7 @@
     "material": [ "steel", "wood", "chitin" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 9 } } ],
     "charges_per_use": 1,
-    "ammo": "essence_type",
+    "tool_ammo": "essence_type",
     "relic_data": {
       "passive_effects": [
         {
@@ -325,7 +325,7 @@
       ]
     },
     "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_pestilence", "no_fail": true, "need_wielding": true, "level": 0 } ],
-    "relative": { "weight": 540, "melee_damage": { "bash": 2 } },
+    "relative": { "weight": "540g", "melee_damage": { "bash": 2 } },
     "extend": { "flags": [ "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_KEEP_EQUIPPED" ] }
   },
   {
@@ -945,7 +945,7 @@
     "symbol": ";",
     "color": "brown",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 5 } } ],
-    "ammo": "essence_blood_type",
+    "tool_ammo": "essence_blood_type",
     "weight": "707 g",
     "volume": "750 ml",
     "longest_side": "45 cm",
@@ -986,7 +986,7 @@
     "color": "brown",
     "turns_per_charge": 1,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 5 } } ],
-    "ammo": "essence_blood_type",
+    "tool_ammo": "essence_blood_type",
     "revert_to": "bloodaxe",
     "use_action": {
       "type": "message",
@@ -1021,7 +1021,7 @@
     "material": [ "qt_steel", "silver" ],
     "symbol": "/",
     "color": "light_gray",
-    "ammo": [ "flintlock" ],
+    "tool_ammo": [ "flintlock" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "flintlock": 2 } } ],
     "techniques": [ "RAPID", "WBLOCK_2", "PRECISE" ],
     "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 9 ] ],
@@ -1064,8 +1064,8 @@
     "melee_damage": { "bash": 9, "cut": 29 },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 8 } } ],
     "charges_per_use": 2,
-    "ammo": "essence_blood_type",
-    "relative": { "weight": 230 },
+    "tool_ammo": "essence_blood_type",
+    "relative": { "weight": "230g" },
     "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_lichhook", "no_fail": true, "need_wielding": true, "level": 0 } ],
     "extend": { "flags": [ "NO_SALVAGE", "SHEATH_SWORD" ] }
   },
@@ -1179,7 +1179,7 @@
     "color": "dark_gray",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_pure_type": 1 } } ],
     "charges_per_use": 1,
-    "ammo": "essence_pure_type",
+    "tool_ammo": "essence_pure_type",
     "relic_data": {
       "passive_effects": [
         {
@@ -1215,7 +1215,7 @@
     "color": "light_gray",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 300 } } ],
     "charges_per_use": 1,
-    "ammo": "essence_dull_type",
+    "tool_ammo": "essence_dull_type",
     "use_action": [
       {
         "type": "repair_item",
@@ -1279,7 +1279,7 @@
     "melee_damage": { "bash": 5 },
     "price": "8500 USD",
     "price_postapoc": "80 USD",
-    "ammo": [ "battery" ],
+    "tool_ammo": [ "battery" ],
     "charges_per_use": 3000,
     "pocket_data": [
       {
@@ -1325,7 +1325,7 @@
     "looks_like": "copper_knife",
     "symbol": ";",
     "color": "red",
-    "ammo": [ "essence_dull_type" ],
+    "tool_ammo": [ "essence_dull_type" ],
     "charges_per_use": 2,
     "use_action": [
       "OXYTORCH",
@@ -1376,7 +1376,7 @@
     "looks_like": "teleporter",
     "symbol": ";",
     "color": "magenta",
-    "ammo": [ "essence_type" ],
+    "tool_ammo": [ "essence_type" ],
     "charges_per_use": 1,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "essence_type": 20 }, "rigid": true } ],
     "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_spatial_displacement", "no_fail": true, "level": 0 } ]
@@ -1424,7 +1424,7 @@
     "color": "yellow",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 10 } } ],
     "charges_per_use": 2,
-    "ammo": "essence_type",
+    "tool_ammo": "essence_type",
     "relic_data": {
       "passive_effects": [
         {
@@ -1469,7 +1469,7 @@
     "techniques": [ "WHIP_DISARM" ],
     "melee_damage": { "bash": 3, "cut": 21 },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 24 } } ],
-    "ammo": "essence_blood_type",
+    "tool_ammo": "essence_blood_type",
     "relic_data": {
       "passive_effects": [ { "has": "WIELD", "condition": "ACTIVE", "hit_you_effect": [ { "id": "arcana_react_drain_life", "once_in": 5 } ] } ]
     },
@@ -1528,7 +1528,7 @@
     "repairs_like": "blood_athame",
     "color": "dark_gray",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 10 } } ],
-    "ammo": "essence_type",
+    "tool_ammo": "essence_type",
     "techniques": [ "RAPID", "DEF_DISARM" ],
     "qualities": [ [ "BUTCHER", 6 ] ],
     "relic_data": {
@@ -1605,7 +1605,7 @@
     "color": "light_gray",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_pure_type": 10 } } ],
     "charges_per_use": 1,
-    "ammo": "essence_pure_type",
+    "tool_ammo": "essence_pure_type",
     "use_action": [
       {
         "type": "consume_drug",
@@ -1652,7 +1652,7 @@
     "color": "red",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 10 } } ],
     "charges_per_use": 10,
-    "ammo": "essence_blood_type",
+    "tool_ammo": "essence_blood_type",
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You fuel the heart with blood essence, and feel its power resonate through you…",
@@ -1679,7 +1679,7 @@
     "color": "red",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 30 } } ],
     "charges_per_use": 5,
-    "ammo": "essence_blood_type",
+    "tool_ammo": "essence_blood_type",
     "relic_data": {
       "passive_effects": [
         {
@@ -1718,7 +1718,7 @@
     "melee_damage": { "bash": 15, "cut": 41 },
     "color": "dark_gray",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 9 } } ],
-    "ammo": "essence_blood_type",
+    "tool_ammo": "essence_blood_type",
     "relic_data": {
       "passive_effects": [
         {
@@ -1757,7 +1757,7 @@
     "description": "A two-handed sword, blade made of a dark metal, engraved with unfamiliar symbols.  You feel as if the blade thirsts for blood, refusing to leave your grasp until it is sated.",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 9 } } ],
     "turns_per_charge": 200,
-    "ammo": "essence_blood_type",
+    "tool_ammo": "essence_blood_type",
     "revert_to": "stormbringer",
     "revert_msg": "The malevolent energy fades from the cursed blade, returning it to normal.",
     "weight": "2267 g",

--- a/Arcana/monsters/monstergroups.json
+++ b/Arcana/monsters/monstergroups.json
@@ -28,8 +28,8 @@
       { "monster": "mon_homunculus", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_albino_penguin", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_dementia", "weight": 700 },
-      { "monster": "mon_feral_summoner", "freq": 50, "cost_multiplier": 0, "starts": 250 },
-      { "monster": "mon_feral_sanguinist", "freq": 50, "cost_multiplier": 0, "starts": 500 }
+      { "monster": "mon_feral_summoner", "freq": 50, "cost_multiplier": 0, "starts": "250 hours" },
+      { "monster": "mon_feral_sanguinist", "freq": 50, "cost_multiplier": 0, "starts": "500 hours" }
     ]
   },
   {
@@ -51,7 +51,7 @@
       { "monster": "mon_hunting_horror", "freq": 250, "cost_multiplier": 0 },
       { "monster": "mon_yugg", "freq": 75, "cost_multiplier": 0 },
       { "monster": "mon_gozu", "freq": 25, "cost_multiplier": 0 },
-      { "monster": "mon_feral_summoner", "freq": 100, "cost_multiplier": 0, "starts": 250 }
+      { "monster": "mon_feral_summoner", "freq": 100, "cost_multiplier": 0, "starts": "250 hours" }
     ]
   },
   {
@@ -67,17 +67,17 @@
       { "monster": "mon_flying_polyp", "weight": 25, "cost_multiplier": 0 },
       { "monster": "mon_flaming_eye", "weight": 25, "cost_multiplier": 0 },
       { "monster": "mon_blank", "weight": 100 },
-      { "monster": "mon_feral_magehunter", "freq": 100, "cost_multiplier": 0, "starts": 500 }
+      { "monster": "mon_feral_magehunter", "freq": 100, "cost_multiplier": 0, "starts": "500 hours" }
     ]
   },
   {
     "type": "monstergroup",
     "id": "GROUP_ARCHON",
     "monsters": [
-      { "monster": "mon_shadow_snake_summoned", "weight": 400, "cost_multiplier": 0, "starts": 72 },
-      { "monster": "mon_shadow_summoned", "weight": 250, "cost_multiplier": 0, "starts": 120 },
-      { "monster": "mon_hunting_horror_summoned", "weight": 50, "cost_multiplier": 0, "starts": 336 },
-      { "monster": "mon_vortex_summoned", "weight": 50, "cost_multiplier": 0, "starts": 168 },
+      { "monster": "mon_shadow_snake_summoned", "weight": 400, "cost_multiplier": 0, "starts": "72 hours" },
+      { "monster": "mon_shadow_summoned", "weight": 250, "cost_multiplier": 0, "starts": "120 hours" },
+      { "monster": "mon_hunting_horror_summoned", "weight": 50, "cost_multiplier": 0, "starts": "336 hours" },
+      { "monster": "mon_vortex_summoned", "weight": 50, "cost_multiplier": 0, "starts": "168 hours" },
       { "monster": "mon_archon", "weight": 0, "cost_multiplier": 0 },
       { "monster": "mon_null", "weight": 250 }
     ]
@@ -86,13 +86,13 @@
     "type": "monstergroup",
     "id": "GROUP_ARCHON_TEMPLE",
     "monsters": [
-      { "monster": "mon_shadow_snake_summoned", "weight": 400, "cost_multiplier": 0, "starts": 72 },
-      { "monster": "mon_shadow_summoned", "weight": 250, "cost_multiplier": 0, "starts": 120 },
-      { "monster": "mon_hunting_horror_summoned", "weight": 50, "cost_multiplier": 0, "starts": 336 },
-      { "monster": "mon_vortex_summoned", "weight": 50, "cost_multiplier": 0, "starts": 168 },
+      { "monster": "mon_shadow_snake_summoned", "weight": 400, "cost_multiplier": 0, "starts": "72 hours" },
+      { "monster": "mon_shadow_summoned", "weight": 250, "cost_multiplier": 0, "starts": "120 hours" },
+      { "monster": "mon_hunting_horror_summoned", "weight": 50, "cost_multiplier": 0, "starts": "336 hours" },
+      { "monster": "mon_vortex_summoned", "weight": 50, "cost_multiplier": 0, "starts": "168 hours" },
       { "monster": "mon_null", "weight": 150 },
-      { "monster": "mon_feral_summoner", "freq": 50, "cost_multiplier": 0, "starts": 250 },
-      { "monster": "mon_feral_keeper", "freq": 50, "cost_multiplier": 0, "starts": 500 }
+      { "monster": "mon_feral_summoner", "freq": 50, "cost_multiplier": 0, "starts": "250 hours" },
+      { "monster": "mon_feral_keeper", "freq": 50, "cost_multiplier": 0, "starts": "500 hours" }
     ]
   },
   {
@@ -103,8 +103,8 @@
       { "monster": "mon_gracke", "freq": 275, "cost_multiplier": 0 },
       { "monster": "mon_gozu", "freq": 100, "cost_multiplier": 0 },
       { "monster": "mon_flesh_angel", "freq": 50, "cost_multiplier": 0 },
-      { "monster": "mon_feral_summoner", "freq": 50, "cost_multiplier": 0, "starts": 250 },
-      { "monster": "mon_feral_magehunter", "freq": 75, "cost_multiplier": 0, "starts": 500 },
+      { "monster": "mon_feral_summoner", "freq": 50, "cost_multiplier": 0, "starts": "250 hours" },
+      { "monster": "mon_feral_magehunter", "freq": 75, "cost_multiplier": 0, "starts": "500 hours" },
       { "monster": "mon_dementia", "weight": 450 }
     ]
   },
@@ -116,8 +116,8 @@
       { "monster": "mon_kreck", "freq": 175, "cost_multiplier": 0 },
       { "monster": "mon_homunculus", "freq": 150, "cost_multiplier": 0 },
       { "monster": "mon_hunting_horror", "freq": 100, "cost_multiplier": 0 },
-      { "monster": "mon_feral_summoner", "freq": 50, "cost_multiplier": 0, "starts": 250 },
-      { "monster": "mon_feral_sanguinist", "freq": 75, "cost_multiplier": 0, "starts": 500 },
+      { "monster": "mon_feral_summoner", "freq": 50, "cost_multiplier": 0, "starts": "250 hours" },
+      { "monster": "mon_feral_sanguinist", "freq": 75, "cost_multiplier": 0, "starts": "500 hours" },
       { "monster": "mon_dementia", "weight": 450 }
     ]
   },
@@ -130,8 +130,8 @@
       { "monster": "mon_flaming_eye", "freq": 100, "cost_multiplier": 0 },
       { "monster": "mon_flying_polyp", "freq": 25, "cost_multiplier": 0 },
       { "monster": "mon_flesh_angel", "freq": 50, "cost_multiplier": 0 },
-      { "monster": "mon_feral_summoner", "freq": 50, "cost_multiplier": 0, "starts": 250 },
-      { "monster": "mon_feral_keeper", "freq": 75, "cost_multiplier": 0, "starts": 500 },
+      { "monster": "mon_feral_summoner", "freq": 50, "cost_multiplier": 0, "starts": "250 hours" },
+      { "monster": "mon_feral_keeper", "freq": 75, "cost_multiplier": 0, "starts": "500 hours" },
       { "monster": "mon_dementia", "weight": 450 }
     ]
   },
@@ -141,10 +141,10 @@
     "monsters": [
       { "monster": "mon_shadow_snake_summoned", "weight": 400, "cost_multiplier": 0 },
       { "monster": "mon_hunting_horror_summoned", "weight": 100, "cost_multiplier": 0 },
-      { "monster": "mon_feral_summoner", "freq": 10, "cost_multiplier": 0, "starts": 125 },
-      { "monster": "mon_feral_magehunter", "freq": 5, "cost_multiplier": 0, "starts": 250 },
-      { "monster": "mon_feral_keeper", "freq": 5, "cost_multiplier": 0, "starts": 250 },
-      { "monster": "mon_feral_sanguinist", "freq": 5, "cost_multiplier": 0, "starts": 250 },
+      { "monster": "mon_feral_summoner", "freq": 10, "cost_multiplier": 0, "starts": "125 hours" },
+      { "monster": "mon_feral_magehunter", "freq": 5, "cost_multiplier": 0, "starts": "250 hours" },
+      { "monster": "mon_feral_keeper", "freq": 5, "cost_multiplier": 0, "starts": "250 hours" },
+      { "monster": "mon_feral_sanguinist", "freq": 5, "cost_multiplier": 0, "starts": "250 hours" },
       { "monster": "mon_seraphic_shade", "weight": 0, "cost_multiplier": 0 },
       { "monster": "mon_shadow_summoned", "weight": 500 }
     ]
@@ -185,10 +185,10 @@
     "override": false,
     "auto_total": true,
     "monsters": [
-      { "monster": "mon_feral_summoner", "freq": 10, "cost_multiplier": 5, "starts": 250 },
-      { "monster": "mon_feral_magehunter", "freq": 4, "cost_multiplier": 5, "starts": 500 },
-      { "monster": "mon_feral_keeper", "freq": 4, "cost_multiplier": 5, "starts": 500 },
-      { "monster": "mon_feral_sanguinist", "freq": 2, "cost_multiplier": 10, "starts": 500 }
+      { "monster": "mon_feral_summoner", "freq": 10, "cost_multiplier": 5, "starts": "250 hours" },
+      { "monster": "mon_feral_magehunter", "freq": 4, "cost_multiplier": 5, "starts": "500 hours" },
+      { "monster": "mon_feral_keeper", "freq": 4, "cost_multiplier": 5, "starts": "500 hours" },
+      { "monster": "mon_feral_sanguinist", "freq": 2, "cost_multiplier": 10, "starts": "500 hours" }
     ]
   },
   {
@@ -196,13 +196,13 @@
     "type": "monstergroup",
     "override": false,
     "auto_total": true,
-    "monsters": [ { "monster": "mon_feral_magehunter", "freq": 10, "cost_multiplier": 10, "starts": 500 } ]
+    "monsters": [ { "monster": "mon_feral_magehunter", "freq": 10, "cost_multiplier": 10, "starts": "500 hours" } ]
   },
   {
     "id": "GROUP_CHURCH_BLANK",
     "type": "monstergroup",
     "override": false,
     "auto_total": true,
-    "monsters": [ { "monster": "mon_feral_magehunter", "freq": 25, "cost_multiplier": 5, "starts": 250 } ]
+    "monsters": [ { "monster": "mon_feral_magehunter", "freq": 25, "cost_multiplier": 5, "starts": "250 hours" } ]
   }
 ]


### PR DESCRIPTION
Hi,

This is my first time using git so please handle this with appropriate lack of respect for my competence.

Was installing the latest experimental and got a bunch of errors, I went into the files and changed the following and it stopped the errors:

The book fields "fun" and "skill" are now "read_fun" and "read_skill" as per https://github.com/CleverRaven/Cataclysm-DDA/pull/80490

The tool ammo field "ammo" is now "tool_ammo" as per https://github.com/CleverRaven/Cataclysm-DDA/pull/80490

"weight" field no longer accepts int, added changed from eg 123 to "123g". Note there were only int values in the relative section on those files, and I'm not 100% on what that function does so hopefully it doesn't break anything. I assumed the weights were in grams.

"starts" field also no longer accepts int, I made similar changes assuming the numbers were hours.