### PR TITLE
Via Gladium et Malleo & Magiclysm

### DIFF
--- a/Arcana/mod_interactions/magiclysm/martialarts.json
+++ b/Arcana/mod_interactions/magiclysm/martialarts.json
@@ -37,7 +37,8 @@
         "gunblade",
         "stormhammer",
         "mjolnir",
-        "gram"
+        "gram",
+        "longsword_holy"
       ]
     }
   },


### PR DESCRIPTION
Via Gladium et Malleo can be used with mage blade(former holy blade) from technomancer class.