### PR TITLE
Pending BN Update: biollante and fungal fighter harvest changes

### DIFF
--- a/Arcana_BN/monsters/monster_drops.json
+++ b/Arcana_BN/monsters/monster_drops.json
@@ -278,7 +278,7 @@
     "type": "item_group",
     "id": "mon_fungal_fighter_death_drops",
     "subtype": "collection",
-    "entries": [ { "group": "fungal_sting", "prob": 85 }, { "item": "iron_thorn" }, { "item": "essence", "prob": 50 } ]
+    "entries": [ { "item": "iron_thorn" }, { "item": "essence", "prob": 50 } ]
   },
   {
     "type": "item_group",
@@ -302,7 +302,7 @@
     "type": "item_group",
     "id": "mon_biollante_death_drops",
     "subtype": "collection",
-    "entries": [ { "item": "inflorescent_root" }, { "group": "biollante", "prob": 80 }, { "item": "essence", "prob": 15 } ]
+    "entries": [ { "item": "inflorescent_root" }, { "item": "essence", "prob": 15 } ]
   },
   {
     "type": "item_group",


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6734 is merged, removing biollante buds and fungal fighter stings from death drop overrides now that they're belatedly being moved to harvest contents.