### PR TITLE
Pending BN update: support for exotic melee damagetypes

### DIFF
--- a/Arcana_BN/items/ranged.json
+++ b/Arcana_BN/items/ranged.json
@@ -126,8 +126,19 @@
     "price": "1000 USD",
     "price_postapoc": "50 USD",
     "to_hit": -1,
-    "bashing": 12,
-    "cutting": 10,
+    "attacks": [
+      {
+        "id": "STAB",
+        "to_hit": 1,
+        "damage": {
+          "values": [
+            { "damage_type": "bash", "amount": 12 },
+            { "damage_type": "stab", "amount": 8 },
+            { "damage_type": "cold", "amount": 4 }
+          ]
+        }
+      }
+    ],
     "material": [ "iron", "silver" ],
     "symbol": "(",
     "color": "light_gray",

--- a/Arcana_BN/items/tools.json
+++ b/Arcana_BN/items/tools.json
@@ -234,7 +234,19 @@
       { "type": "firestarter", "moves": 30 },
       { "menu_text": "Turn off", "type": "transform", "msg": "The sword's radiance fades.", "target": "sun_sword" }
     ],
-    "cutting": 40,
+    "attacks": [
+      {
+        "id": "SLASH",
+        "to_hit": 1,
+        "damage": {
+          "values": [
+            { "damage_type": "bash", "amount": 10 },
+            { "damage_type": "cut", "amount": 32 },
+            { "damage_type": "light", "amount": 8 }
+          ]
+        }
+      }
+    ],
     "extend": { "flags": [ "FIRE", "LIGHT_240", "CHARGEDIM", "FLAMING", "NONCONDUCTIVE" ] },
     "delete": { "flags": [ "SHEATH_SWORD" ] }
   },
@@ -980,8 +992,19 @@
     "price": "1000 USD",
     "price_postapoc": "50 USD",
     "to_hit": 2,
-    "bashing": 12,
-    "cutting": 30,
+    "attacks": [
+      {
+        "id": "STAB",
+        "to_hit": 1,
+        "damage": {
+          "values": [
+            { "damage_type": "bash", "amount": 12 },
+            { "damage_type": "stab", "amount": 20 },
+            { "damage_type": "cold", "amount": 10 }
+          ]
+        }
+      }
+    ],
     "material": [ "iron", "silver" ],
     "symbol": "/",
     "color": "light_gray",
@@ -1740,8 +1763,19 @@
     "price": "45000 USD",
     "price_postapoc": "120 USD",
     "to_hit": 2,
-    "bashing": 16,
-    "cutting": 50,
+    "attacks": [
+      {
+        "id": "SLASH",
+        "to_hit": 1,
+        "damage": {
+          "values": [
+            { "damage_type": "bash", "amount": 16 },
+            { "damage_type": "cut", "amount": 37 },
+            { "damage_type": "dark", "amount": 13 }
+          ]
+        }
+      }
+    ],
     "material": [ "steel", "essencemat" ],
     "symbol": "/",
     "looks_like": "stormbringer",


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6963 is merged. Adds light damage to active incorruptible sword, swaps out `FLAMING` flag for simply using an on-hit relic effect that can ignite targets (and daze them, which makes it effective at shutting down regen for many Arcana monsters), gives shrike's misericorde cold-type damage, and gives active cursed blade dark-type damage.